### PR TITLE
Refactor: rename component classes from plural to singular

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,12 +52,12 @@ Reverse: `CFASTParser` reads an existing `.in` file via `f90nml` and reconstruct
 
 All simulation elements are standalone classes (no shared base class):
 - `SimulationEnvironment` — title, duration, time step, initial conditions
-- `Compartments` — room geometry, materials, leakage
-- `MaterialProperties` — thermal properties referenced by ID from Compartments/Devices
-- `Fires` — heat release rate, chemistry, compartment placement
-- `WallVents` / `CeilingFloorVents` / `MechanicalVents` — connections between compartments by ID
-- `Devices` — targets (heat transfer probes) and detectors (heat/smoke/sprinkler)
-- `SurfaceConnections` — adjacent surface heat transfer
+- `Compartment` — room geometry, materials, leakage
+- `Material` — thermal properties referenced by ID from Compartment/Device
+- `Fire` — heat release rate, chemistry, compartment placement
+- `WallVent` / `CeilingFloorVent` / `MechanicalVent` — connections between compartments by ID
+- `Device` — targets (heat transfer probes) and detectors (heat/smoke/sprinkler)
+- `SurfaceConnection` — adjacent surface heat transfer
 
 Each component implements:
 - `to_input_string()` → Fortran namelist fragment via `NamelistRecord`

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ PyCFAST can be seen as an alternative to the CFAST graphical interface, CEdit. I
 <td align="center"><strong>PyCFAST (Python)</strong></td>
 </tr>
 <tr>
-<td><img src="docs/source/_static/images/cedit-compartments-tab.png" alt="CEdit Compartments Tab" width="400"></td>
+<td><img src="docs/source/_static/images/cedit-compartments-tab.png" alt="CEdit Compartment Tab" width="400"></td>
 <td>
 
 ```python
-from pycfast import Compartments
+from pycfast import Compartment
 
-room = Compartments(
+room = Compartment(
     id="Comp 1",
     width=10.0,
     depth=10.0,
@@ -52,11 +52,11 @@ room = Compartments(
 This minimal model runs with just a title and one compartment with default values:
 
 ```python
-from pycfast import CFASTModel, Compartments, SimulationEnvironment
+from pycfast import CFASTModel, Compartment, SimulationEnvironment
 
 model = CFASTModel(
     simulation_environment=SimulationEnvironment(title="My Simulation"),
-    compartments=[Compartments()],
+    compartments=[Compartment()],
     # you can also add: fires, wall_vents, ceiling_floor_vents, mechanical_vents, ...
     file_name="my_simulation.in",
 )
@@ -68,24 +68,24 @@ For a full model with all components:
 
 ```python
 from pycfast import (
-    CeilingFloorVents,
+    CeilingFloorVent,
     CFASTModel,
-    Compartments,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 model = CFASTModel(
     simulation_environment=SimulationEnvironment(...),
-    material_properties=[MaterialProperties(...)],
-    compartments=[Compartments(...)],
-    wall_vents=[WallVents(...)],
-    ceiling_floor_vents=[CeilingFloorVents(...)],
-    mechanical_vents=[MechanicalVents(...)],
-    fires=[Fires(...)],
+    material_properties=[Material(...)],
+    compartments=[Compartment(...)],
+    wall_vents=[WallVent(...)],
+    ceiling_floor_vents=[CeilingFloorVent(...)],
+    mechanical_vents=[MechanicalVent(...)],
+    fires=[Fire(...)],
     file_name="test_simulation.in",
 )
 ```

--- a/docs/source/api/components.rst
+++ b/docs/source/api/components.rst
@@ -11,12 +11,12 @@ CFAST models are composed of various components that represent different aspects
    :nosignatures:
    :recursive:
 
-   CeilingFloorVents
-   Compartments
-   Devices
-   Fires
-   MaterialProperties
-   MechanicalVents
+   CeilingFloorVent
+   Compartment
+   Device
+   Fire
+   Material
+   MechanicalVent
    SimulationEnvironment
-   SurfaceConnections
-   WallVents
+   SurfaceConnection
+   WallVent

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -13,11 +13,11 @@ This minimal model runs with just a title and one compartment with default value
 
 .. code-block:: python
 
-    from pycfast import CFASTModel, Compartments, SimulationEnvironment
+    from pycfast import CFASTModel, Compartment, SimulationEnvironment
 
     model = CFASTModel(
         simulation_environment=SimulationEnvironment(title="My Simulation"),
-        compartments=[Compartments()],
+        compartments=[Compartment()],
         # you can also add: fires, wall_vents, ceiling_floor_vents, mechanical_vents, material_properties
         file_name="my_simulation.in",
     )
@@ -32,18 +32,18 @@ You will have a ``my_simulation.in`` file saved in your working directory, which
 Complete Example
 ^^^^^^^^^^^^^^^^
 
-A more complete model with two :class:`~pycfast.Compartments` connected by a :class:`~pycfast.WallVents` and a :class:`~pycfast.Fires` in the first room. Components reference each other with an ID to be able to connect them together.
+A more complete model with two :class:`~pycfast.Compartment` connected by a :class:`~pycfast.WallVent` and a :class:`~pycfast.Fire` in the first room. Components reference each other with an ID to be able to connect them together.
 
 .. code-block:: python
 
-    from pycfast import CFASTModel, Compartments, Fires, SimulationEnvironment, WallVents
+    from pycfast import CFASTModel, Compartment, Fire, SimulationEnvironment, WallVent
 
     # Two compartments connected by a door
-    room1 = Compartments(id="ROOM1", width=5.0, depth=4.0, height=2.7)
-    room2 = Compartments(id="ROOM2", width=4.0, depth=4.0, height=2.7)
+    room1 = Compartment(id="ROOM1", width=5.0, depth=4.0, height=2.7)
+    room2 = Compartment(id="ROOM2", width=4.0, depth=4.0, height=2.7)
 
     # Door between the two rooms (references compartment IDs)
-    wall_vent = WallVents(
+    wall_vent = WallVent(
         id="wallvent",
         comps_ids=["ROOM1", "ROOM2"],  # connects ROOM1 and ROOM2
         bottom=0.0,
@@ -63,7 +63,7 @@ A more complete model with two :class:`~pycfast.Compartments` connected by a :cl
     ]
 
     # Fire in ROOM1 (references compartment ID)
-    fire = Fires(
+    fire = Fire(
         id="FIRE1",
         comp_id="ROOM1",  # placed in ROOM1
         fire_id="POLYURETHANE",
@@ -80,7 +80,7 @@ A more complete model with two :class:`~pycfast.Compartments` connected by a :cl
     )
     model.save()
 
-Other components (:class:`~pycfast.CeilingFloorVents`, :class:`~pycfast.Devices`, :class:`~pycfast.MaterialProperties`, :class:`~pycfast.MechanicalVents`, :class:`~pycfast.SurfaceConnections`) follow the same pattern and are documented in the :doc:`API reference <api/index>`.
+Other components (:class:`~pycfast.CeilingFloorVent`, :class:`~pycfast.Device`, :class:`~pycfast.Material`, :class:`~pycfast.MechanicalVent`, :class:`~pycfast.SurfaceConnection`) follow the same pattern and are documented in the :doc:`API reference <api/index>`.
 
 Importing Existing Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -118,10 +118,10 @@ PyCFAST provides flexible methods to modify your models dynamically:
 
 .. code-block:: python
 
-    from pycfast import Compartments
+    from pycfast import Compartment
 
     # Add new components
-    new_compartment = Compartments(...)
+    new_compartment = Compartment(...)
     model = model.add_compartments(new_compartment)
 
     # Update existing components (by index or ID)

--- a/examples/plot_01_basic_usage.py
+++ b/examples/plot_01_basic_usage.py
@@ -12,16 +12,16 @@ We'll build a complete simulation with two compartments, ventilation, fire sourc
 # ------------------------------------------
 # First, let's import all the necessary PyCFAST components.
 from pycfast import (
-    CeilingFloorVents,
+    CeilingFloorVent,
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    SurfaceConnections,
-    WallVents,
+    SurfaceConnection,
+    WallVent,
 )
 
 # %%
@@ -54,7 +54,7 @@ simulation_env
 # %%
 # Step 3: Define Material Properties
 # ----------------------------------
-# Material properties define the thermal characteristics of surfaces in our compartments. The :class:`~pycfast.MaterialProperties` class is the equivalent of the CEdit simulation settings tab but programmatically defined.
+# Material properties define the thermal characteristics of surfaces in our compartments. The :class:`~pycfast.Material` class is the equivalent of the CEdit simulation settings tab but programmatically defined.
 #
 # .. figure:: /_static/images/cedit-material-properties-tab.png
 #    :alt: CEdit Material Properties Tab
@@ -63,7 +63,7 @@ simulation_env
 #
 # Here we define gypsum board, which is commonly used for walls and ceilings.
 
-gypsum_board = MaterialProperties(
+gypsum_board = Material(
     id="Gypboard",  # Unique identifier for the material
     material="Gypsum Board",  # Descriptive name
     conductivity=0.16,  # Thermal conductivity in W/m·K (not in kW as CEdit shows)
@@ -79,18 +79,18 @@ gypsum_board = MaterialProperties(
 gypsum_board
 
 # %%
-# Step 4: Create Compartments
+# Step 4: Create Compartment
 # ---------------------------
-# Compartments represent the physical spaces in our building. The :class:`~pycfast.Compartments` class is the equivalent of the CEdit compartment tab but programmatically defined.
+# Compartment represent the physical spaces in our building. The :class:`~pycfast.Compartment` class is the equivalent of the CEdit compartment tab but programmatically defined.
 #
 # .. figure:: /_static/images/cedit-compartments-tab.png
-#    :alt: CEdit Compartments Tab
+#    :alt: CEdit Compartment Tab
 #    :width: 800px
 #
 #
 # We'll create two 10×10×10 meter rooms stacked vertically.
 
-ground_level = Compartments(
+ground_level = Compartment(
     id="Comp 1",
     depth=10.0,  # Depth in meters (Y-direction)
     height=10.0,  # Height in meters (Z-direction)
@@ -106,7 +106,7 @@ ground_level = Compartments(
     origin_z=0,  # Z-coordinate of origin
 )
 
-upper_level = Compartments(
+upper_level = Compartment(
     id="Comp 2",
     depth=10.0,
     height=10.0,
@@ -152,11 +152,11 @@ ground_level
 #           :alt: CEdit Mechanical Ventilation Tab
 #           :width: 200px
 #
-# We'll use the :class:`~pycfast.MechanicalVents`, :class:`~pycfast.CeilingFloorVents`, and :class:`~pycfast.WallVents` classes to define our vents.
+# We'll use the :class:`~pycfast.MechanicalVent`, :class:`~pycfast.CeilingFloorVent`, and :class:`~pycfast.WallVent` classes to define our vents.
 
 # Wall vent connecting first compartment to outside
 
-wall_vent = WallVents(
+wall_vent = WallVent(
     id="WallVent_1",
     comps_ids=["Comp 1", "OUTSIDE"],  # Connect compartment 1 to outside
     bottom=0.02,  # Height of bottom of vent in meters
@@ -165,7 +165,7 @@ wall_vent = WallVents(
     face="FRONT",  # Wall face (FRONT, BACK, LEFT, RIGHT)
     offset=0.47,
 )
-ceiling_floor_vents = CeilingFloorVents(
+ceiling_floor_vents = CeilingFloorVent(
     id="CeilFloorVent_1",
     comps_ids=["Comp 2", "Comp 1"],  # Connect compartment 2 to compartment 1
     area=0.01,  # Vent area in m²
@@ -174,7 +174,7 @@ ceiling_floor_vents = CeilingFloorVents(
     offsets=[0.84, 0.86],
 )
 
-mechanical_vents = MechanicalVents(
+mechanical_vents = MechanicalVent(
     id="mech",
     comps_ids=["OUTSIDE", "Comp 1"],  # Connect outside to compartment 1
     area=[1.2, 10],  # Areas at each end in m²
@@ -195,16 +195,16 @@ wall_vent
 # %%
 # Step 6: Define Fire Sources
 # ---------------------------
-# Fire sources represent the combustion processes in our simulation. The :class:`~pycfast.Fires` class is the equivalent of the CEdit fires tab but programmatically defined.
+# Fire sources represent the combustion processes in our simulation. The :class:`~pycfast.Fire` class is the equivalent of the CEdit fires tab but programmatically defined.
 #
 # .. figure:: /_static/images/cedit-fires-tab.png
-#    :alt: CEdit Fires Tab
+#    :alt: CEdit Fire Tab
 #    :width: 800px
 #
 #
 # Here we define a propane fire with specific chemical composition and heat release characteristics.
 
-propane_fire = Fires(
+propane_fire = Fire(
     id="Propane",
     comp_id="Comp 1",  # Location: first compartment
     fire_id="Propane_Fire",
@@ -249,23 +249,23 @@ propane_fire = Fires(
 )
 
 # %%
-# Step 7: Add Devices
+# Step 7: Add Device
 # -------------------
-# Devices allow us to monitor conditions at specific locations. The :class:`~pycfast.Devices` class is the equivalent of the CEdit devices tab but programmatically defined.
+# Device allow us to monitor conditions at specific locations. The :class:`~pycfast.Device` class is the equivalent of the CEdit devices tab but programmatically defined.
 #
 # .. figure:: /_static/images/cedit-targets-tab.png
 #    :alt: CEdit Target Tab
 #    :width: 800px
 #
 #
-# The :class:`~pycfast.Devices` class has classmethods to help create common device types:
-# * :meth:`~pycfast.Devices.create_target`: equivalent of target device
-# * :meth:`~pycfast.Devices.create_heat_detector`: equivalent of heat detector device
-# * :meth:`~pycfast.Devices.create_smoke_detector`: equivalent of smoke detector device
-# * :meth:`~pycfast.Devices.create_sprinkler`: equivalent of sprinkler device
+# The :class:`~pycfast.Device` class has classmethods to help create common device types:
+# * :meth:`~pycfast.Device.create_target`: equivalent of target device
+# * :meth:`~pycfast.Device.create_heat_detector`: equivalent of heat detector device
+# * :meth:`~pycfast.Device.create_smoke_detector`: equivalent of smoke detector device
+# * :meth:`~pycfast.Device.create_sprinkler`: equivalent of sprinkler device
 #
 # Here we add a target device to measure thermal conditions.
-target = Devices.create_target(
+target = Device.create_target(
     id="Target_1",
     comp_id="Comp 1",  # Location: first compartment
     location=[0.5, 0.5, 0],  # X,Y,Z coordinates
@@ -285,17 +285,17 @@ target
 # %%
 # Step 8: Configure Surface Connections
 # -------------------------------------
-# Surface connections define thermal connections between compartments through shared surfaces. The :class:`~pycfast.SurfaceConnections` class is the equivalent of the CEdit surface connections tab but programmatically defined.
+# Surface connections define thermal connections between compartments through shared surfaces. The :class:`~pycfast.SurfaceConnection` class is the equivalent of the CEdit surface connections tab but programmatically defined.
 #
 # .. figure:: /_static/images/cedit-surface-connections-tab.png
 #    :alt: CEdit Surface Connections
 #    :width: 800px
 #
 #
-# The :class:`~pycfast.SurfaceConnections` class has 2 classmethods to help create common connection types :meth:`~pycfast.SurfaceConnections.ceiling_floor_connection`, and :meth:`~pycfast.SurfaceConnections.wall_connection`.
+# The :class:`~pycfast.SurfaceConnection` class has 2 classmethods to help create common connection types :meth:`~pycfast.SurfaceConnection.ceiling_floor_connection`, and :meth:`~pycfast.SurfaceConnection.wall_connection`.
 # Here we create a ceiling/floor connection between the two compartments to allow heat transfer and air flow between them.
 
-ceiling_floor_connection = SurfaceConnections.ceiling_floor_connection(
+ceiling_floor_connection = SurfaceConnection.ceiling_floor_connection(
     comp_id="Comp 1",  # Source compartment
     comp_ids="Comp 2",  # Target compartment
 )
@@ -415,7 +415,7 @@ for device in model.devices:
     print(device)
 
 # After adding a new device
-new_device = Devices.create_target(
+new_device = Device.create_target(
     id="Target_2",
     comp_id="Comp 2",  # Location: second compartment
     location=[0.5, 0.5, 0.5],  # X,Y,Z coordinates

--- a/examples/plot_02_parsing_cfast_input_files.py
+++ b/examples/plot_02_parsing_cfast_input_files.py
@@ -13,7 +13,7 @@ This example explains how to use PyCFAST's parser to read and analyze existing C
 
 import os
 
-from pycfast import MaterialProperties
+from pycfast import Material
 from pycfast.parsers import parse_cfast_file
 
 # %%
@@ -67,7 +67,7 @@ updated_model = model.update_simulation_params(
 )
 
 # Add a new material with :meth:`~pycfast.CFASTModel.add_material`
-new_material = MaterialProperties(
+new_material = Material(
     id="Steel",
     material="Steel Plate",
     conductivity=45.0,

--- a/examples/plot_06_surrogate_models.py
+++ b/examples/plot_06_surrogate_models.py
@@ -5,7 +5,7 @@
 
 
 Build surrogate model machine learning models to predict CFAST outputs instantly instead of running full simulations.
-**Goal**: Predict Target Surface Temperature of the devices (:class:`~pycfast.Devices` TRGSURT) from fire parameters: heat of combustion, radiative fraction, soot yield and target z position
+**Goal**: Predict Target Surface Temperature of the devices (:class:`~pycfast.Device` TRGSURT) from fire parameters: heat of combustion, radiative fraction, soot yield and target z position
 **Models**: Linear → Polynomial → Gradient Boosting → Random Forest → Neural Network (PyTorch)
 """
 

--- a/src/pycfast/__init__.py
+++ b/src/pycfast/__init__.py
@@ -13,32 +13,32 @@ import logging
 from importlib.metadata import version
 
 from . import datasets
-from .ceiling_floor_vents import CeilingFloorVents
-from .compartments import Compartments
-from .devices import Devices
-from .fires import Fires
-from .material_properties import MaterialProperties
-from .mechanical_vents import MechanicalVents
+from .ceiling_floor_vent import CeilingFloorVent
+from .compartment import Compartment
+from .device import Device
+from .fire import Fire
+from .material import Material
+from .mechanical_vent import MechanicalVent
 from .model import CFASTModel
 from .simulation_environment import SimulationEnvironment
-from .surface_connections import SurfaceConnections
-from .wall_vents import WallVents
+from .surface_connection import SurfaceConnection
+from .wall_vent import WallVent
 
 logging.getLogger("pycfast").addHandler(logging.NullHandler())
 
 __all__ = [
     "datasets",
     "CFAST_VERSION",
-    "CeilingFloorVents",
-    "Compartments",
-    "Devices",
-    "Fires",
-    "MaterialProperties",
-    "MechanicalVents",
+    "CeilingFloorVent",
+    "Compartment",
+    "Device",
+    "Fire",
+    "Material",
+    "MechanicalVent",
     "CFASTModel",
     "SimulationEnvironment",
-    "SurfaceConnections",
-    "WallVents",
+    "SurfaceConnection",
+    "WallVent",
 ]
 
 __version__ = version("pycfast")

--- a/src/pycfast/ceiling_floor_vent.py
+++ b/src/pycfast/ceiling_floor_vent.py
@@ -1,7 +1,7 @@
 """
 Ceiling/Floor Vents definition module for CFAST simulations.
 
-This module provides the CeilingFloorVents class for defining vertical
+This module provides the CeilingFloorVent class for defining vertical
 flow vent connections between compartments.
 """
 
@@ -14,7 +14,7 @@ from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class CeilingFloorVents:
+class CeilingFloorVent:
     """
     Represents vertical flow vent connections between compartments.
 
@@ -97,7 +97,7 @@ class CeilingFloorVents:
     --------
     Create a ceiling/floor vent connection:
 
-    >>> vent = CeilingFloorVents(
+    >>> vent = CeilingFloorVent(
     ...     id="HOLE1",
     ...     comps_ids=["UPPER_RM", "LOWER_RM"],  # top, bottom
     ...     area=1.0,           # 1.0 m² cross-sectional area
@@ -162,7 +162,7 @@ class CeilingFloorVents:
 
         if self.area < 0:
             raise ValueError(
-                f"CeilingFloorVents '{self.id}': area must be non-negative, got {self.area}."
+                f"CeilingFloorVent '{self.id}': area must be non-negative, got {self.area}."
             )
 
         for label, val in (
@@ -171,27 +171,27 @@ class CeilingFloorVents:
         ):
             if val is not None and not 0.0 <= val <= 1.0:
                 raise ValueError(
-                    f"CeilingFloorVents '{self.id}': {label}={val} must be in [0, 1]."
+                    f"CeilingFloorVent '{self.id}': {label}={val} must be in [0, 1]."
                 )
 
         if self.fraction is not None:
             for i, f in enumerate(self.fraction):
                 if not 0.0 <= f <= 1.0:
                     raise ValueError(
-                        f"CeilingFloorVents '{self.id}': fraction[{i}]={f} must be in [0, 1]."
+                        f"CeilingFloorVent '{self.id}': fraction[{i}]={f} must be in [0, 1]."
                     )
 
         if self.area == 0:
             warnings.warn(
-                f"CeilingFloorVents '{self.id}': area=0 means no flow will occur through this vent.",
+                f"CeilingFloorVent '{self.id}': area=0 means no flow will occur through this vent.",
                 UserWarning,
                 stacklevel=2,
             )
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the CeilingFloorVents."""
+        """Return a detailed string representation of the CeilingFloorVent."""
         return (
-            f"CeilingFloorVents("
+            f"CeilingFloorVent("
             f"id='{self.id}', "
             f"comps_ids={self.comps_ids}, "
             f"area={self.area}, type='{self.type}', shape='{self.shape}', "
@@ -200,7 +200,7 @@ class CeilingFloorVents:
         )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the CeilingFloorVents."""
+        """Return a user-friendly string representation of the CeilingFloorVent."""
         connection = f"{self.comps_ids[0]} ↕ {self.comps_ids[1]}"
         area_info = f"area: {self.area} m²"
         shape_info = f"shape: {self.shape}"
@@ -248,7 +248,7 @@ class CeilingFloorVents:
     def __getitem__(self, key: str) -> Any:
         """Get vent property by name for dictionary-like access."""
         if not hasattr(self, key):
-            raise KeyError(f"Property '{key}' not found in CeilingFloorVents.")
+            raise KeyError(f"Property '{key}' not found in CeilingFloorVent.")
         return getattr(self, key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -266,7 +266,7 @@ class CeilingFloorVents:
         """
         if not hasattr(self, key):
             raise KeyError(
-                f"Cannot set '{key}'. Property does not exist in CeilingFloorVents."
+                f"Cannot set '{key}'. Property does not exist in CeilingFloorVent."
             )
         old_value = getattr(self, key)
         setattr(self, key, value)
@@ -287,7 +287,7 @@ class CeilingFloorVents:
 
         Examples
         --------
-        >>> vent = CeilingFloorVents("HOLE1", ["RM_UP", "RM_LOW"], 1.0, "ROUND")
+        >>> vent = CeilingFloorVent("HOLE1", ["RM_UP", "RM_LOW"], 1.0, "ROUND")
         >>> print(vent.to_input_string())
         &VENT TYPE = 'FLOOR' ID = 'HOLE1' COMP_IDS = 'RM_UP', 'RM_LOW' ...
         """

--- a/src/pycfast/compartment.py
+++ b/src/pycfast/compartment.py
@@ -1,7 +1,7 @@
 """
-Compartments definition module for CFAST simulations.
+Compartment definition module for CFAST simulations.
 
-This module provides the Compartments class for defining the size, position,
+This module provides the Compartment class for defining the size, position,
 materials of construction, and flow characteristics for the compartments in
 the CFAST simulation.
 """
@@ -10,15 +10,16 @@ from __future__ import annotations
 
 from typing import Any
 
+from .component import CFASTComponent
 from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class Compartments:
+class Compartment(CFASTComponent):
     """
     Defines the size, position, materials of construction, and flow characteristics for compartments.
 
-    The Compartments page defines the size, position, materials of construction, and flow
+    The Compartment page defines the size, position, materials of construction, and flow
     characteristics for the compartments in the simulation. In order to model a fire scenario,
     the size and position of each compartment relevant to the scenario must be specified. For a
     compartment, the width, depth, compartment height and height of the floor of the compartment
@@ -114,7 +115,7 @@ class Compartments:
     --------
     Create a compartment following CFAST conventions:
 
-    >>> room = Compartments(
+    >>> room = Compartment(
     ...     id="BEDROOM",
     ...     width=3.5, depth=4.0, height=2.4,  # Size specification
     ...     ceiling_mat_id="GYPSUM", ceiling_thickness=0.016,
@@ -214,9 +215,9 @@ class Compartments:
                 )
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the Compartments."""
+        """Return a detailed string representation of the Compartment."""
         return (
-            f"Compartments("
+            f"Compartment("
             f"id='{self.id}', "
             f"width={self.width}, depth={self.depth}, height={self.height}, "
             f"ceiling_mat_id='{self.ceiling_mat_id}', wall_mat_id='{self.wall_mat_id}', "
@@ -226,7 +227,7 @@ class Compartments:
         )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the Compartments."""
+        """Return a user-friendly string representation of the Compartment."""
         volume = None
         if (
             self.width is not None
@@ -383,7 +384,7 @@ class Compartments:
 
         Examples
         --------
-        >>> comp = Compartments("ROOM1", width=3.0, depth=4.0, height=2.4,
+        >>> comp = Compartment("ROOM1", width=3.0, depth=4.0, height=2.4,
         ...                    ceiling_mat_id="GYPSUM", ceiling_thickness=0.016,
         ...                    wall_mat_id="GYPSUM", wall_thickness=0.016,
         ...                    floor_mat_id="CONCRETE", floor_thickness=0.10,

--- a/src/pycfast/component.py
+++ b/src/pycfast/component.py
@@ -1,0 +1,54 @@
+"""
+Base class for every component (Fire, Device, Material, MechcnicalVent) in CFAST.
+
+This module provides a Component Class that will be herited from every component
+in the library. This class contain serveral common method used by all component.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class CFASTComponent(ABC):
+    """Base class for all CFAST components."""
+
+    def __getitem__(self, key: str) -> Any:
+        """Get component property by name for dictionary-like access."""
+        if not hasattr(self, key):
+            raise KeyError(f"Property '{key}' not found in {self.__class__.__name__}")
+        return getattr(self, key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Set component property by name for dictionary-like assignment.
+
+        Validates the object state after setting the attribute to ensure
+        all constraints are still satisfied.
+
+        Raises
+        ------
+        KeyError
+            If the property does not exist.
+        ValueError
+            If setting this value would violate object constraints.
+        """
+        if not hasattr(self, key):
+            raise KeyError(
+                f"Cannot set '{key}'. Property does not exist in Compartment."
+            )
+        old_value = getattr(self, key)
+        setattr(self, key, value)
+        try:
+            self._validate()
+        except Exception:
+            setattr(self, key, old_value)
+            raise
+
+    @abstractmethod
+    def _validate(self) -> None:
+        """
+        Validate component-specific rules.
+
+        Subclasses must implement their own validation rules.
+        """

--- a/src/pycfast/device.py
+++ b/src/pycfast/device.py
@@ -14,7 +14,7 @@ from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class Devices:
+class Device:
     """
     Represents measurement and fire protection devices in a CFAST simulation.
 
@@ -111,7 +111,7 @@ class Devices:
     --------
     Create a plate target:
 
-    >>> target = Devices(
+    >>> target = Device(
     ...     id="WALL_TARGET",
     ...     comp_id="ROOM1",
     ...     location=[2.0, 3.0, 1.5],     # 2m from left, 3m from front, 1.5m high
@@ -123,7 +123,7 @@ class Devices:
 
     Create a heat detector:
 
-    >>> detector = Devices(
+    >>> detector = Device(
     ...     id="HEAT_DET_1",
     ...     comp_id="KITCHEN",
     ...     location=[2.5, 2.5, 2.4],     # Ceiling mounted
@@ -136,7 +136,7 @@ class Devices:
 
     Create a sprinkler:
 
-    >>> sprinkler = Devices(
+    >>> sprinkler = Device(
     ...     id="SPRINKLER_1",
     ...     comp_id="OFFICE",
     ...     location=[3.0, 3.0, 2.4],     # Ceiling mounted
@@ -150,7 +150,7 @@ class Devices:
 
     Create a smoke detector:
 
-    >>> smoke_det = Devices(
+    >>> smoke_det = Device(
     ...     id="SMOKE_DET_1",
     ...     comp_id="CORRIDOR",
     ...     location=[5.0, 1.0, 2.4],     # Ceiling mounted
@@ -239,12 +239,12 @@ class Devices:
         self._validate()
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the Devices."""
+        """Return a detailed string representation of the Device."""
         location_str = f"[{', '.join(map(str, self.location))}]"
 
         if self.type in {"PLATE", "CYLINDER"}:
             return (
-                f"Devices("
+                f"Device("
                 f"id='{self.id}', type='{self.type}', comp_id='{self.comp_id}', "
                 f"location={location_str}, material_id='{self.material_id}', "
                 f"thickness={self.thickness}, temperature_depth={self.temperature_depth}"
@@ -262,14 +262,14 @@ class Devices:
             detector_str = f", {', '.join(detector_params)}" if detector_params else ""
 
             return (
-                f"Devices("
+                f"Device("
                 f"id='{self.id}', type='{self.type}', comp_id='{self.comp_id}', "
                 f"location={location_str}{detector_str}"
                 f")"
             )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the Devices."""
+        """Return a user-friendly string representation of the Device."""
         location_str = f"({self.location[0]}, {self.location[1]}, {self.location[2]})"
 
         if self.type in {"PLATE", "CYLINDER"}:
@@ -363,7 +363,7 @@ class Devices:
     def __getitem__(self, key: str) -> Any:
         """Get device property by name for dictionary-like access."""
         if not hasattr(self, key):
-            raise KeyError(f"Property '{key}' not found in Devices.")
+            raise KeyError(f"Property '{key}' not found in Device.")
         return getattr(self, key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -380,7 +380,7 @@ class Devices:
             If setting this value would violate object constraints.
         """
         if not hasattr(self, key):
-            raise KeyError(f"Cannot set '{key}'. Property does not exist in Devices.")
+            raise KeyError(f"Cannot set '{key}'. Property does not exist in Device.")
         old_value = getattr(self, key)
         setattr(self, key, value)
         try:
@@ -496,7 +496,7 @@ class Devices:
 
         Examples
         --------
-        >>> target = Devices.create_target(
+        >>> target = Device.create_target(
         ...     id="WALL_TARGET",
         ...     comp_id="ROOM1",
         ...     location=[2.0, 3.0, 1.5],
@@ -559,7 +559,7 @@ class Devices:
         depth_units: str = "M",
         adiabatic: bool = False,
         convection_coefficients: list[float] | None = None,
-    ) -> Devices:
+    ) -> Device:
         """
         Create a target device.
 
@@ -588,7 +588,7 @@ class Devices:
 
         Returns
         -------
-        Devices
+        Device
             Device instance configured as a target
 
         Raises
@@ -629,7 +629,7 @@ class Devices:
         location: list[float | int],
         setpoint: float,
         rti: float,
-    ) -> Devices:
+    ) -> Device:
         """
         Create a heat detector.
 
@@ -648,7 +648,7 @@ class Devices:
 
         Returns
         -------
-        Devices
+        Device
             Device instance configured as a heat detector
         """
         return cls(
@@ -669,7 +669,7 @@ class Devices:
         location: list[float | int],
         setpoint: float,
         obscuration: float = 23.93,
-    ) -> Devices:
+    ) -> Device:
         """
         Create a smoke detector.
 
@@ -688,7 +688,7 @@ class Devices:
 
         Returns
         -------
-        Devices
+        Device
             Device instance configured as a smoke detector
         """
         return cls(
@@ -710,7 +710,7 @@ class Devices:
         setpoint: float,
         rti: float,
         spray_density: float,
-    ) -> Devices:
+    ) -> Device:
         """
         Create a sprinkler.
 
@@ -731,7 +731,7 @@ class Devices:
 
         Returns
         -------
-        Devices
+        Device
             Device instance configured as a sprinkler
         """
         return cls(

--- a/src/pycfast/fire.py
+++ b/src/pycfast/fire.py
@@ -1,7 +1,7 @@
 """
 Fire definition module for CFAST simulations.
 
-This module provides the Fires class for defining fire sources in a
+This module provides the Fire class for defining fire sources in a
 compartment. Fires are characterized by their heat release rate over time,
 chemical composition, and physical properties.
 """
@@ -18,7 +18,7 @@ from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class Fires:
+class Fire:
     """
     Represents a fire source in a CFAST simulation.
 
@@ -107,7 +107,7 @@ class Fires:
     ...     [60, 100, 0.5, 0.5, 0.01, 0.01, 0, 0, 0],   # t=60s, 100 kW
     ...     [300, 500, 1.0, 1.0, 0.01, 0.01, 0, 0, 0]   # t=300s, 500 kW peak
     ... ]
-    >>> fire = Fires(
+    >>> fire = Fire(
     ...     id="FIRE1",
     ...     comp_id="ROOM1",
     ...     fire_id="POLYURETHANE",
@@ -120,7 +120,7 @@ class Fires:
 
     Create a fire with target-based ignition:
 
-    >>> steady_fire = Fires(
+    >>> steady_fire = Fire(
     ...     id="IGNITED_FIRE",
     ...     comp_id="BEDROOM",
     ...     fire_id="WOOD",
@@ -221,12 +221,12 @@ class Fires:
             )
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the Fires."""
+        """Return a detailed string representation of the Fire."""
         location_str = f"[{', '.join(map(str, self.location))}]"
         data_rows = len(self.data_table) if self.data_table else 0
 
         return (
-            f"Fires("
+            f"Fire("
             f"id='{self.id}', comp_id='{self.comp_id}', fire_id='{self.fire_id}', "
             f"location={location_str}, "
             f"heat_of_combustion={self.heat_of_combustion}, "
@@ -236,7 +236,7 @@ class Fires:
         )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the Fires."""
+        """Return a user-friendly string representation of the Fire."""
         location_str = f"({self.location[0]}, {self.location[1]})"
 
         peak_hrr: float = 0
@@ -342,7 +342,7 @@ class Fires:
     def __getitem__(self, key: str) -> Any:
         """Get fire property by name for dictionary-like access."""
         if not hasattr(self, key):
-            raise KeyError(f"Property '{key}' not found in Fires.")
+            raise KeyError(f"Property '{key}' not found in Fire.")
         return getattr(self, key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -359,7 +359,7 @@ class Fires:
             If setting this value would violate object constraints.
         """
         if not hasattr(self, key):
-            raise KeyError(f"Cannot set '{key}'. Property does not exist in Fires.")
+            raise KeyError(f"Cannot set '{key}'. Property does not exist in Fire.")
         old_value = getattr(self, key)
         setattr(self, key, value)
         try:
@@ -379,7 +379,7 @@ class Fires:
 
         Examples
         --------
-        >>> fire = Fires(id="FIRE1", comp_id="ROOM1", fire_id="WOOD",
+        >>> fire = Fire(id="FIRE1", comp_id="ROOM1", fire_id="WOOD",
         ...               location=[1.0, 1.0], data_table=[[0, 1000, 0.5, 1.0, 0.01, 0.01, 0, 0, 0]])
         >>> print(fire.to_input_string())
         &FIRE ID = 'FIRE1' COMP_ID = 'ROOM1' FIRE_ID = 'WOOD' LOCATION = 1.0, 1.0 /
@@ -450,7 +450,7 @@ class Fires:
 
         Examples
         --------
-        >>> fire = Fires(id="FIRE1", comp_id="ROOM1", fire_id="WOOD",
+        >>> fire = Fire(id="FIRE1", comp_id="ROOM1", fire_id="WOOD",
         ...               location=[1.0, 1.0],
         ...               data_table=[[0, 1000, 0.5, 1.0, 0.01, 0.01, 0, 0, 0]])
         >>> df = fire.to_dataframe()

--- a/src/pycfast/material.py
+++ b/src/pycfast/material.py
@@ -1,7 +1,7 @@
 """
 Material thermal property definitions for CFAST simulations.
 
-This module provides the MaterialProperties class for defining
+This module provides the Material class for defining
 thermophysical properties of materials used in CFAST simulations.
 """
 
@@ -14,7 +14,7 @@ from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class MaterialProperties:
+class Material:
     """
     Defines thermophysical properties of materials used for compartment surfaces or targets.
 
@@ -56,7 +56,7 @@ class MaterialProperties:
     --------
     Create a gypsum wallboard material:
 
-    >>> gypsum = MaterialProperties(
+    >>> gypsum = Material(
     ...     id="GYPSUM",
     ...     material="Gypsum Wallboard",
     ...     conductivity=0.17,
@@ -108,21 +108,21 @@ class MaterialProperties:
         ):
             if val is not None and val <= 0:
                 raise ValueError(
-                    f"MaterialProperties '{self.id}': {prop} must be positive, got {val}."
+                    f"Material '{self.id}': {prop} must be positive, got {val}."
                 )
 
         if self.emissivity is not None and not 0.0 <= self.emissivity <= 1.0:
             warnings.warn(
-                f"MaterialProperties '{self.id}': emissivity={self.emissivity} is outside [0, 1]."
+                f"Material '{self.id}': emissivity={self.emissivity} is outside [0, 1]."
                 "This may cause inaccurate results.",
                 UserWarning,
                 stacklevel=2,
             )
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the MaterialProperties."""
+        """Return a detailed string representation of the Material."""
         return (
-            f"MaterialProperties("
+            f"Material("
             f"id='{self.id}', material='{self.material}', "
             f"conductivity={self.conductivity}, density={self.density}, "
             f"specific_heat={self.specific_heat}, thickness={self.thickness}, "
@@ -131,7 +131,7 @@ class MaterialProperties:
         )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the MaterialProperties."""
+        """Return a user-friendly string representation of the Material."""
         return (
             f"Material '{self.id}' ({self.material}): "
             f"k={self.conductivity}, ρ={self.density}, c={self.specific_heat}, "
@@ -162,7 +162,7 @@ class MaterialProperties:
     def __getitem__(self, key: str) -> Any:
         """Get material property by name for dictionary-like access."""
         if not hasattr(self, key):
-            raise KeyError(f"Property '{key}' not found in MaterialProperties.")
+            raise KeyError(f"Property '{key}' not found in Material.")
         return getattr(self, key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -179,9 +179,7 @@ class MaterialProperties:
             If setting this value would violate object constraints.
         """
         if not hasattr(self, key):
-            raise KeyError(
-                f"Cannot set '{key}'. Property does not exist in MaterialProperties."
-            )
+            raise KeyError(f"Cannot set '{key}'. Property does not exist in Material.")
         old_value = getattr(self, key)
         setattr(self, key, value)
         try:
@@ -201,7 +199,7 @@ class MaterialProperties:
 
         Examples
         --------
-        >>> mat = MaterialProperties("GYPSUM", "Gypsum Board", 0.17, 930, 1.09, 0.016, 0.9)
+        >>> mat = Material("GYPSUM", "Gypsum Board", 0.17, 930, 1.09, 0.016, 0.9)
         >>> print(mat.to_input_string().strip())
         &MATL ID = 'GYPSUM' MATERIAL = 'Gypsum Board' CONDUCTIVITY = 0.17 DENSITY = 930 SPECIFIC_HEAT = 1.09 THICKNESS = 0.016 EMISSIVITY = 0.9 /
         """

--- a/src/pycfast/mechanical_vent.py
+++ b/src/pycfast/mechanical_vent.py
@@ -1,7 +1,7 @@
 """
 Mechanical ventilation system definition module for CFAST simulations.
 
-This module provides the MechanicalVents class for defining HVAC systems,
+This module provides the MechanicalVent class for defining HVAC systems,
 fans, and forced ventilation that actively move air between compartments
 or to/from the exterior.
 """
@@ -15,7 +15,7 @@ from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class MechanicalVents:
+class MechanicalVent:
     """
     Represents a mechanical ventilation system in a CFAST simulation.
 
@@ -115,7 +115,7 @@ class MechanicalVents:
     --------
     Create a supply air system:
 
-    >>> supply_fan = MechanicalVents(
+    >>> supply_fan = MechanicalVent(
     ...     id="SUPPLY_1",
     ...     comps_ids=["OUTSIDE", "ROOM1"],
     ...     area=[0.1, 0.1],              # 0.1 m² grilles
@@ -130,7 +130,7 @@ class MechanicalVents:
 
     Create an exhaust fan with time-based control:
 
-    >>> exhaust_fan = MechanicalVents(
+    >>> exhaust_fan = MechanicalVent(
     ...     id="EXHAUST_1",
     ...     comps_ids=["KITCHEN", "OUTSIDE"],
     ...     area=[0.05, 0.05],            # Smaller exhaust grilles
@@ -232,7 +232,7 @@ class MechanicalVents:
         for i, a in enumerate(self.area):
             if a < 0:
                 raise ValueError(
-                    f"MechanicalVents '{self.id}': area[{i}]={a} must be non-negative."
+                    f"MechanicalVent '{self.id}': area[{i}]={a} must be non-negative."
                 )
 
         if (
@@ -240,7 +240,7 @@ class MechanicalVents:
             and not 0.0 <= self.filter_efficiency <= 100.0
         ):
             raise ValueError(
-                f"MechanicalVents '{self.id}': filter_efficiency={self.filter_efficiency} "
+                f"MechanicalVent '{self.id}': filter_efficiency={self.filter_efficiency} "
                 "must be in [0, 100] (percentage)."
             )
 
@@ -248,21 +248,21 @@ class MechanicalVents:
             for i, f in enumerate(self.fraction):
                 if not 0.0 <= f <= 1.0:
                     raise ValueError(
-                        f"MechanicalVents '{self.id}': fraction[{i}]={f} must be in [0, 1]."
+                        f"MechanicalVent '{self.id}': fraction[{i}]={f} must be in [0, 1]."
                     )
 
         if self.filter_time is not None and self.filter_time < 0:
             warnings.warn(
-                f"MechanicalVents '{self.id}': filter_time={self.filter_time} is negative. "
+                f"MechanicalVent '{self.id}': filter_time={self.filter_time} is negative. "
                 "This may cause unexpected behaviour.",
                 UserWarning,
                 stacklevel=2,
             )
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the MechanicalVents."""
+        """Return a detailed string representation of the MechanicalVent."""
         return (
-            f"MechanicalVents("
+            f"MechanicalVent("
             f"id='{self.id}', "
             f"comps_ids={self.comps_ids}, "
             f"flow={self.flow}, "
@@ -272,7 +272,7 @@ class MechanicalVents:
         )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the MechanicalVents."""
+        """Return a user-friendly string representation of the MechanicalVent."""
         connection = f"{self.comps_ids[0]} -> {self.comps_ids[1]}"
         flow_str = f"flow: {self.flow} m³/s"
         return f"Mechanical Vent '{self.id}': {connection}, {flow_str}"
@@ -322,7 +322,7 @@ class MechanicalVents:
     def __getitem__(self, key: str) -> Any:
         """Get vent property by name for dictionary-like access."""
         if not hasattr(self, key):
-            raise KeyError(f"Property '{key}' not found in MechanicalVents.")
+            raise KeyError(f"Property '{key}' not found in MechanicalVent.")
         return getattr(self, key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -340,7 +340,7 @@ class MechanicalVents:
         """
         if not hasattr(self, key):
             raise KeyError(
-                f"Cannot set '{key}'. Property does not exist in MechanicalVents."
+                f"Cannot set '{key}'. Property does not exist in MechanicalVent."
             )
         old_value = getattr(self, key)
         setattr(self, key, value)
@@ -361,7 +361,7 @@ class MechanicalVents:
 
         Examples
         --------
-        >>> vent = MechanicalVents("FAN1", ["OUT", "RM1"], [0.1, 0.1],
+        >>> vent = MechanicalVent("FAN1", ["OUT", "RM1"], [0.1, 0.1],
         ...                       [3, 2.8], ["HORIZ", "HORIZ"], 0.5,
         ...                       [100, 100], [0, 1], 0, 0)
         >>> print(vent.to_input_string())

--- a/src/pycfast/model.py
+++ b/src/pycfast/model.py
@@ -19,17 +19,17 @@ from typing import Any, cast
 import numpy as np
 import pandas as pd
 
-from .ceiling_floor_vents import CeilingFloorVents
-from .compartments import Compartments
-from .devices import Devices
-from .fires import Fires
-from .material_properties import MaterialProperties
-from .mechanical_vents import MechanicalVents
+from .ceiling_floor_vent import CeilingFloorVent
+from .compartment import Compartment
+from .device import Device
+from .fire import Fire
+from .material import Material
+from .mechanical_vent import MechanicalVent
 from .simulation_environment import SimulationEnvironment
-from .surface_connections import SurfaceConnections
+from .surface_connection import SurfaceConnection
 from .utils import CSV_READ_CONFIGS
 from .utils.theme import build_card
-from .wall_vents import WallVents
+from .wall_vent import WallVent
 
 logger = logging.getLogger("pycfast")
 
@@ -94,19 +94,19 @@ class CFASTModel:
     ----------
     simulation_environment: SimulationEnvironment
         Basic simulation parameters and settings
-    material_properties: List[MaterialProperties]
+    material_properties: List[Material]
         List of material property definitions
-    compartments: List[Compartments]
+    compartments: List[Compartment]
         List of compartment/room definitions
-    wall_vents: List[WallVents]
+    wall_vents: List[WallVent]
         List of wall vent connections between compartments
-    ceiling_floor_vents: List[CeilingFloorVents]
+    ceiling_floor_vents: List[CeilingFloorVent]
         List of ceiling/floor vent connections
-    mechanical_vents: List[MechanicalVents]
+    mechanical_vents: List[MechanicalVent]
         List of mechanical ventilation systems
-    fires: List[Fires]
+    fires: List[Fire]
         List of fire definitions
-    targets: List[Devices]
+    targets: List[Device]
         List of target/sensor definitions
     file_name: str
         Name of the CFAST input file to generate
@@ -143,14 +143,14 @@ class CFASTModel:
     def __init__(
         self,
         simulation_environment: SimulationEnvironment,
-        compartments: list[Compartments],
-        material_properties: list[MaterialProperties] | None = None,
-        wall_vents: list[WallVents] | None = None,
-        ceiling_floor_vents: list[CeilingFloorVents] | None = None,
-        mechanical_vents: list[MechanicalVents] | None = None,
-        fires: list[Fires] | None = None,
-        devices: list[Devices] | None = None,
-        surface_connections: list[SurfaceConnections] | None = None,
+        compartments: list[Compartment],
+        material_properties: list[Material] | None = None,
+        wall_vents: list[WallVent] | None = None,
+        ceiling_floor_vents: list[CeilingFloorVent] | None = None,
+        mechanical_vents: list[MechanicalVent] | None = None,
+        fires: list[Fire] | None = None,
+        devices: list[Device] | None = None,
+        surface_connections: list[SurfaceConnection] | None = None,
         file_name: str = "cfast_input.in",
         cfast_exe: str | None = None,
         extra_arguments: list[str] | None = None,
@@ -215,7 +215,7 @@ class CFASTModel:
             )
             components_html += f"""
             <details class="pycfast-detail">
-                <summary><strong>Compartments</strong> ({len(self.compartments)})</summary>
+                <summary><strong>Compartment</strong> ({len(self.compartments)})</summary>
                 <ul style="margin: 5px 0; padding-left: 20px;">{comp_details}</ul>
             </details>
             """
@@ -229,7 +229,7 @@ class CFASTModel:
             )
             components_html += f"""
             <details class="pycfast-detail">
-                <summary><strong>Fires</strong> ({len(self.fires)})</summary>
+                <summary><strong>Fire</strong> ({len(self.fires)})</summary>
                 <ul style="margin: 5px 0; padding-left: 20px;">{fire_details}</ul>
             </details>
             """
@@ -279,7 +279,7 @@ class CFASTModel:
             )
             components_html += f"""
             <details class="pycfast-detail">
-                <summary><strong>Devices</strong> ({len(self.devices)})</summary>
+                <summary><strong>Device</strong> ({len(self.devices)})</summary>
                 <ul style="margin: 5px 0; padding-left: 20px;">{device_details}</ul>
             </details>
             """
@@ -509,7 +509,7 @@ class CFASTModel:
             New fire data table to replace existing one. Must have 9 columns:
             TIME, HRR, HEIGHT, AREA, CO_YIELD, SOOT_YIELD, HCN_YIELD, HCL_YIELD, TRACE_YIELD.
         **kwargs : Any
-            Fire object attributes to update. See Fires class documentation
+            Fire object attributes to update. See Fire class documentation
             for available parameters.
 
         Returns
@@ -670,7 +670,7 @@ class CFASTModel:
         compartment_index : int, optional
             Deprecated. Use 'compartment' parameter instead.
         **kwargs : Any
-            Compartment attributes to update. See Compartments class documentation
+            Compartment attributes to update. See Compartment class documentation
             for available parameters.
 
         Returns
@@ -742,7 +742,7 @@ class CFASTModel:
         material_index : int, optional
             Deprecated. Use 'material' parameter instead.
         **kwargs : Any
-            Material properties attributes to update. See MaterialProperties class
+            Material properties attributes to update. See Material class
             documentation for available parameters.
 
         Returns
@@ -809,7 +809,7 @@ class CFASTModel:
         vent_index : int, optional
             Deprecated. Use 'vent' parameter instead.
         **kwargs : Any
-            Wall vent attributes to update. See WallVents class documentation
+            Wall vent attributes to update. See WallVent class documentation
             for available parameters.
 
         Returns
@@ -876,7 +876,7 @@ class CFASTModel:
         vent_index : int, optional
             Deprecated. Use 'vent' parameter instead.
         **kwargs : Any
-            Ceiling/floor vent attributes to update. See CeilingFloorVents class
+            Ceiling/floor vent attributes to update. See CeilingFloorVent class
             documentation for available parameters.
 
         Returns
@@ -942,7 +942,7 @@ class CFASTModel:
         vent_index : int, optional
             Deprecated. Use 'vent' parameter instead.
         **kwargs : Any
-            Mechanical vent attributes to update. See MechanicalVents class
+            Mechanical vent attributes to update. See MechanicalVent class
             documentation for available parameters.
 
         Returns
@@ -1008,7 +1008,7 @@ class CFASTModel:
         device_index : int, optional
             Deprecated. Use 'device' parameter instead.
         **kwargs : Any
-            Device attributes to update. See Devices class documentation
+            Device attributes to update. See Device class documentation
             for available parameters.
 
         Returns
@@ -1072,7 +1072,7 @@ class CFASTModel:
         connection_index : int, optional
             Deprecated. Use 'connection' parameter instead.
         **kwargs : Any
-            Surface connection attributes to update. See SurfaceConnections class
+            Surface connection attributes to update. See SurfaceConnection class
             documentation for available parameters.
 
         Returns
@@ -1117,13 +1117,13 @@ class CFASTModel:
 
         return new_model
 
-    def add_fire(self, fire: Fires) -> CFASTModel:
+    def add_fire(self, fire: Fire) -> CFASTModel:
         """
         Add a fire to the model and return a new model instance.
 
         Parameters
         ----------
-        fire : Fires
+        fire : Fire
             Fire object to add to the model
 
         Returns
@@ -1133,20 +1133,20 @@ class CFASTModel:
 
         Examples
         --------
-        >>> new_fire = Fires(id="FIRE2", comp_id="ROOM1", location=[2.0, 2.0])
+        >>> new_fire = Fire(id="FIRE2", comp_id="ROOM1", location=[2.0, 2.0])
         >>> updated_model = model.add_fire(new_fire)
         """
         new_model = copy.deepcopy(self)
         new_model.fires.append(fire)
         return new_model
 
-    def add_compartment(self, compartment: Compartments) -> CFASTModel:
+    def add_compartment(self, compartment: Compartment) -> CFASTModel:
         """
         Add a compartment to the model and return a new model instance.
 
         Parameters
         ----------
-        compartment : Compartments
+        compartment : Compartment
             Compartment object to add to the model
 
         Returns
@@ -1156,20 +1156,20 @@ class CFASTModel:
 
         Examples
         --------
-        >>> new_room = Compartments(id="ROOM3", width=5.0, depth=4.0, height=3.0)
+        >>> new_room = Compartment(id="ROOM3", width=5.0, depth=4.0, height=3.0)
         >>> updated_model = model.add_compartment(new_room)
         """
         new_model = copy.deepcopy(self)
         new_model.compartments.append(compartment)
         return new_model
 
-    def add_material(self, material: MaterialProperties) -> CFASTModel:
+    def add_material(self, material: Material) -> CFASTModel:
         """
         Add a material property to the model and return a new model instance.
 
         Parameters
         ----------
-        material : MaterialProperties
+        material : Material
             Material properties object to add to the model
 
         Returns
@@ -1179,20 +1179,20 @@ class CFASTModel:
 
         Examples
         --------
-        >>> steel = MaterialProperties(id="STEEL", conductivity=45.0, density=7850)
+        >>> steel = Material(id="STEEL", conductivity=45.0, density=7850)
         >>> updated_model = model.add_material(steel)
         """
         new_model = copy.deepcopy(self)
         new_model.material_properties.append(material)
         return new_model
 
-    def add_wall_vent(self, vent: WallVents) -> CFASTModel:
+    def add_wall_vent(self, vent: WallVent) -> CFASTModel:
         """
         Add a wall vent to the model and return a new model instance.
 
         Parameters
         ----------
-        vent : WallVents
+        vent : WallVent
             Wall vent object to add to the model
 
         Returns
@@ -1202,20 +1202,20 @@ class CFASTModel:
 
         Examples
         --------
-        >>> door = WallVents(comp_ids=["ROOM1", "ROOM2"], width=1.0, height=2.0)
+        >>> door = WallVent(comp_ids=["ROOM1", "ROOM2"], width=1.0, height=2.0)
         >>> updated_model = model.add_wall_vent(door)
         """
         new_model = copy.deepcopy(self)
         new_model.wall_vents.append(vent)
         return new_model
 
-    def add_ceiling_floor_vent(self, vent: CeilingFloorVents) -> CFASTModel:
+    def add_ceiling_floor_vent(self, vent: CeilingFloorVent) -> CFASTModel:
         """
         Add a ceiling/floor vent to the model and return a new model instance.
 
         Parameters
         ----------
-        vent : CeilingFloorVents
+        vent : CeilingFloorVent
             Ceiling/floor vent object to add to the model
 
         Returns
@@ -1225,20 +1225,20 @@ class CFASTModel:
 
         Examples
         --------
-        >>> hatch = CeilingFloorVents(comp_ids=["ROOM1", "ROOM2"], area=0.5)
+        >>> hatch = CeilingFloorVent(comp_ids=["ROOM1", "ROOM2"], area=0.5)
         >>> updated_model = model.add_ceiling_floor_vent(hatch)
         """
         new_model = copy.deepcopy(self)
         new_model.ceiling_floor_vents.append(vent)
         return new_model
 
-    def add_mechanical_vent(self, vent: MechanicalVents) -> CFASTModel:
+    def add_mechanical_vent(self, vent: MechanicalVent) -> CFASTModel:
         """
         Add a mechanical vent to the model and return a new model instance.
 
         Parameters
         ----------
-        vent : MechanicalVents
+        vent : MechanicalVent
             Mechanical vent object to add to the model
 
         Returns
@@ -1248,20 +1248,20 @@ class CFASTModel:
 
         Examples
         --------
-        >>> hvac = MechanicalVents(comp_ids=["ROOM1", "OUTSIDE"], flow_rate=0.5)
+        >>> hvac = MechanicalVent(comp_ids=["ROOM1", "OUTSIDE"], flow_rate=0.5)
         >>> updated_model = model.add_mechanical_vent(hvac)
         """
         new_model = copy.deepcopy(self)
         new_model.mechanical_vents.append(vent)
         return new_model
 
-    def add_device(self, device: Devices) -> CFASTModel:
+    def add_device(self, device: Device) -> CFASTModel:
         """
         Add a device/target to the model and return a new model instance.
 
         Parameters
         ----------
-        device : Devices
+        device : Device
             Device object to add to the model
 
         Returns
@@ -1271,7 +1271,7 @@ class CFASTModel:
 
         Examples
         --------
-        >>> sensor = Devices.create_heat_detector(
+        >>> sensor = Device.create_heat_detector(
         ...     comp_id="ROOM1", location=[2.0, 2.0, 2.4], temperature=68.0
         ... )
         >>> updated_model = model.add_device(sensor)
@@ -1280,13 +1280,13 @@ class CFASTModel:
         new_model.devices.append(device)
         return new_model
 
-    def add_surface_connection(self, connection: SurfaceConnections) -> CFASTModel:
+    def add_surface_connection(self, connection: SurfaceConnection) -> CFASTModel:
         """
         Add a surface connection to the model and return a new model instance.
 
         Parameters
         ----------
-        connection : SurfaceConnections
+        connection : SurfaceConnection
             Surface connection object to add to the model
 
         Returns
@@ -1296,7 +1296,7 @@ class CFASTModel:
 
         Examples
         --------
-        >>> wall_conn = SurfaceConnections.wall_connection(
+        >>> wall_conn = SurfaceConnection.wall_connection(
         ...     comp_ids=["ROOM1", "ROOM2"], fraction=0.5
         ... )
         >>> updated_model = model.add_surface_connection(wall_conn)
@@ -1585,10 +1585,10 @@ class CFASTModel:
         Simulation: 'Building Fire Test' (3600s)
 
         Material Properties (2):
-            MaterialProperties(material='GYPSUM', conductivity=0.17, density=800...)
+            Material(material='GYPSUM', conductivity=0.17, density=800...)
 
-        Compartments (2):
-            Compartments(id='ROOM1', width=4.0, depth=3.0, height=2.5...)
+        Compartment (2):
+            Compartment(id='ROOM1', width=4.0, depth=3.0, height=2.5...)
         """
         lines: list[str] = []
 
@@ -1604,7 +1604,7 @@ class CFASTModel:
                 lines.append(f"    {mat}")
 
         if self.compartments:
-            lines.append(f"  Compartments ({len(self.compartments)}):")
+            lines.append(f"  Compartment ({len(self.compartments)}):")
             for comp in self.compartments:
                 lines.append(f"    {comp}")
 
@@ -1624,12 +1624,12 @@ class CFASTModel:
                 lines.append(f"    {mechanical_vent}")
 
         if self.fires:
-            lines.append(f"  Fires ({len(self.fires)}):")
+            lines.append(f"  Fire ({len(self.fires)}):")
             for fire in self.fires:
                 lines.append(f"    {fire}")
 
         if self.devices:
-            lines.append(f"  Devices ({len(self.devices)}):")
+            lines.append(f"  Device ({len(self.devices)}):")
             for device in self.devices:
                 lines.append(f"    {device}")
 
@@ -1762,8 +1762,8 @@ class CFASTModel:
                 ("!! Wall Vents", self.wall_vents),
                 ("!! Ceiling and Floor Vents", self.ceiling_floor_vents),
                 ("!! Mechanical Vents", self.mechanical_vents),
-                ("!! Fires", self.fires),
-                ("!! Devices", self.devices),
+                ("!! Fire", self.fires),
+                ("!! Device", self.devices),
                 ("!! Surface Connections", self.surface_connections),
             ]
 
@@ -1855,40 +1855,40 @@ class CFASTModel:
                     f"Device '{device.id}': comp_id='{device.comp_id}' does not match any defined compartment."
                 )
 
-        # comps_ids of vents must exist in compartments ("OUTSIDE" is valid as second comp for WallVents)
+        # comps_ids of vents must exist in compartments ("OUTSIDE" is valid as second comp for WallVent)
         for vent in self.wall_vents:
             if vent.comps_ids[0] not in comp_ids:
                 raise ValueError(
-                    f"WallVents '{vent.id}': comps_ids[0]='{vent.comps_ids[0]}' does not match any defined compartment."
+                    f"WallVent '{vent.id}': comps_ids[0]='{vent.comps_ids[0]}' does not match any defined compartment."
                 )
             if vent.comps_ids[1] != "OUTSIDE" and vent.comps_ids[1] not in comp_ids:
                 raise ValueError(
-                    f"WallVents '{vent.id}': comps_ids[1]='{vent.comps_ids[1]}' does not match any defined compartment."
+                    f"WallVent '{vent.id}': comps_ids[1]='{vent.comps_ids[1]}' does not match any defined compartment."
                 )
 
         for cf_vent in self.ceiling_floor_vents:
             for i, cid in enumerate(cf_vent.comps_ids):
                 if cid != "OUTSIDE" and cid not in comp_ids:
                     raise ValueError(
-                        f"CeilingFloorVents '{cf_vent.id}': comps_ids[{i}]='{cid}' does not match any defined compartment."
+                        f"CeilingFloorVent '{cf_vent.id}': comps_ids[{i}]='{cid}' does not match any defined compartment."
                     )
 
         for m_vent in self.mechanical_vents:
             for i, cid in enumerate(m_vent.comps_ids):
                 if cid != "OUTSIDE" and cid not in comp_ids:
                     raise ValueError(
-                        f"MechanicalVents '{m_vent.id}': comps_ids[{i}]='{cid}' does not match any defined compartment."
+                        f"MechanicalVent '{m_vent.id}': comps_ids[{i}]='{cid}' does not match any defined compartment."
                     )
 
-        # comp_id of SurfaceConnections must exist in compartments
+        # comp_id of SurfaceConnection must exist in compartments
         for sc in self.surface_connections:
             if sc.comp_id not in comp_ids:
                 raise ValueError(
-                    f"SurfaceConnections: comp_id='{sc.comp_id}' does not match any defined compartment."
+                    f"SurfaceConnection: comp_id='{sc.comp_id}' does not match any defined compartment."
                 )
             if sc.comp_ids not in comp_ids:
                 raise ValueError(
-                    f"SurfaceConnections: comp_ids='{sc.comp_ids}' does not match any defined compartment."
+                    f"SurfaceConnection: comp_ids='{sc.comp_ids}' does not match any defined compartment."
                 )
 
         # material_id of Device/Compartment must exist in material_properties
@@ -1917,19 +1917,19 @@ class CFASTModel:
         for vent in self.wall_vents:
             if vent.device_id is not None and vent.device_id not in device_ids:
                 raise ValueError(
-                    f"WallVents '{vent.id}': device_id='{vent.device_id}' does not match any defined device."
+                    f"WallVent '{vent.id}': device_id='{vent.device_id}' does not match any defined device."
                 )
 
         for cf_vent in self.ceiling_floor_vents:
             if cf_vent.device_id is not None and cf_vent.device_id not in device_ids:
                 raise ValueError(
-                    f"CeilingFloorVents '{cf_vent.id}': device_id='{cf_vent.device_id}' does not match any defined device."
+                    f"CeilingFloorVent '{cf_vent.id}': device_id='{cf_vent.device_id}' does not match any defined device."
                 )
 
         for m_vent in self.mechanical_vents:
             if m_vent.device_id is not None and m_vent.device_id not in device_ids:
                 raise ValueError(
-                    f"MechanicalVents '{m_vent.id}': device_id='{m_vent.device_id}' does not match any defined device."
+                    f"MechanicalVent '{m_vent.id}': device_id='{m_vent.device_id}' does not match any defined device."
                 )
 
         comp_map = {c.id: c for c in self.compartments}

--- a/src/pycfast/parsers/cfast_parser.py
+++ b/src/pycfast/parsers/cfast_parser.py
@@ -14,16 +14,16 @@ from typing import Any
 
 import f90nml  # type: ignore
 
-from ..ceiling_floor_vents import CeilingFloorVents
-from ..compartments import Compartments
-from ..devices import Devices
-from ..fires import Fires
-from ..material_properties import MaterialProperties
-from ..mechanical_vents import MechanicalVents
+from ..ceiling_floor_vent import CeilingFloorVent
+from ..compartment import Compartment
+from ..device import Device
+from ..fire import Fire
+from ..material import Material
+from ..mechanical_vent import MechanicalVent
 from ..model import CFASTModel
 from ..simulation_environment import SimulationEnvironment
-from ..surface_connections import SurfaceConnections
-from ..wall_vents import WallVents
+from ..surface_connection import SurfaceConnection
+from ..wall_vent import WallVent
 
 logger = logging.getLogger("pycfast")
 
@@ -62,22 +62,22 @@ class CFASTParser:
     ----------
     simulation_environment: SimulationEnvironment
         object containing simulation settings.
-    material_properties: List[MaterialProperties]
-        List of MaterialProperties objects.
-    compartments: List[Compartments]
-        List of Compartments objects.
-    wall_vents: List[WallVents]
-        List of WallVents objects.
-    ceiling_floor_vents: List[CeilingFloorVents]
-        List of CeilingFloorVents objects.
-    mechanical_vents: List[MechanicalVents]
-        List of MechanicalVents objects.
-    fires: List[Fires]
-        List of Fires objects.
-    devices: List[Devices]
-        List of Devices objects.
-    surface_connections: List[SurfaceConnections]
-        List of SurfaceConnections objects.
+    material_properties: List[Material]
+        List of Material objects.
+    compartments: List[Compartment]
+        List of Compartment objects.
+    wall_vents: List[WallVent]
+        List of WallVent objects.
+    ceiling_floor_vents: List[CeilingFloorVent]
+        List of CeilingFloorVent objects.
+    mechanical_vents: List[MechanicalVent]
+        List of MechanicalVent objects.
+    fires: List[Fire]
+        List of Fire objects.
+    devices: List[Device]
+        List of Device objects.
+    surface_connections: List[SurfaceConnection]
+        List of SurfaceConnection objects.
 
     Examples
     --------
@@ -99,17 +99,17 @@ class CFASTParser:
         self.simulation_environment: SimulationEnvironment = SimulationEnvironment(
             title=""
         )
-        self.material_properties: list[MaterialProperties] = []
-        self.compartments: list[Compartments] = []
-        self.wall_vents: list[WallVents] = []
-        self.ceiling_floor_vents: list[CeilingFloorVents] = []
-        self.mechanical_vents: list[MechanicalVents] = []
-        self.fires: list[Fires] = []
-        self.devices: list[Devices] = []
-        self.surface_connections: list[SurfaceConnections] = []
+        self.material_properties: list[Material] = []
+        self.compartments: list[Compartment] = []
+        self.wall_vents: list[WallVent] = []
+        self.ceiling_floor_vents: list[CeilingFloorVent] = []
+        self.mechanical_vents: list[MechanicalVent] = []
+        self.fires: list[Fire] = []
+        self.devices: list[Device] = []
+        self.surface_connections: list[SurfaceConnection] = []
 
         self._fire_hash_map: dict[
-            str, Fires
+            str, Fire
         ] = {}  # will be useful for merging chemistry, data tables, and fire
 
     def parse_file(
@@ -539,7 +539,7 @@ class CFASTParser:
             "emissivity": {"source": "EMISSIVITY", "required": True, "type": float},
         }
         material_params = self._extract_params(params, param_map)
-        material = MaterialProperties(**material_params)
+        material = Material(**material_params)
         self.material_properties.append(material)
 
     def _parse_compartment_block(self, params: dict[str, Any]) -> None:
@@ -583,7 +583,7 @@ class CFASTParser:
             {"origin_x": origin_x, "origin_y": origin_y, "origin_z": origin_z}
         )
 
-        compartment = Compartments(**compartment_params)
+        compartment = Compartment(**compartment_params)
         self.compartments.append(compartment)
 
     def _parse_vent_block(self, params: dict[str, Any]) -> None:
@@ -600,7 +600,7 @@ class CFASTParser:
             raise ValueError(f"Unknown vent type: {vent_type}")
 
     def _parse_wall_vent(self, params: dict[str, Any]) -> None:
-        """Parse wall vent parameters and create WallVents object."""
+        """Parse wall vent parameters and create WallVent object."""
         param_map = {
             "id": {"source": "ID", "required": True, "type": str},
             "comps_ids": {
@@ -624,11 +624,11 @@ class CFASTParser:
         }
 
         vent_params = self._extract_params(params, param_map)
-        vent = WallVents(**vent_params)
+        vent = WallVent(**vent_params)
         self.wall_vents.append(vent)
 
     def _parse_ceiling_floor_vent(self, params: dict[str, Any]) -> None:
-        """Parse ceiling/floor vent parameters and create CeilingFloorVents object."""
+        """Parse ceiling/floor vent parameters and create CeilingFloorVent object."""
         param_map = {
             "id": {"source": "ID", "required": True, "type": str},
             "comps_ids": {
@@ -651,11 +651,11 @@ class CFASTParser:
         }
 
         vent_params = self._extract_params(params, param_map)
-        vent = CeilingFloorVents(**vent_params)
+        vent = CeilingFloorVent(**vent_params)
         self.ceiling_floor_vents.append(vent)
 
     def _parse_mechanical_vent(self, params: dict[str, Any]) -> None:
-        """Parse mechanical vent parameters and create MechanicalVents object."""
+        """Parse mechanical vent parameters and create MechanicalVent object."""
         param_map = {
             "id": {"source": "ID", "required": True, "type": str},
             "comps_ids": {
@@ -686,7 +686,7 @@ class CFASTParser:
         }
 
         vent_params = self._extract_params(params, param_map)
-        vent = MechanicalVents(**vent_params)
+        vent = MechanicalVent(**vent_params)
         self.mechanical_vents.append(vent)
 
     def _parse_fire_block(self, params: dict[str, Any]) -> None:
@@ -702,7 +702,7 @@ class CFASTParser:
         }
 
         fire_params = self._extract_params(params, param_map)
-        fire = Fires(**fire_params)
+        fire = Fire(**fire_params)
 
         fire.data_table = []
 
@@ -797,7 +797,7 @@ class CFASTParser:
                 },
             }
             device_params = self._extract_params(params, param_map)
-            device = Devices(**device_params)
+            device = Device(**device_params)
 
         elif device_type == "HEAT_DETECTOR":
             param_map = {
@@ -808,7 +808,7 @@ class CFASTParser:
                 "rti": {"source": "RTI", "required": True, "type": float},
             }
             device_params = self._extract_params(params, param_map)
-            device = Devices.create_heat_detector(**device_params)
+            device = Device.create_heat_detector(**device_params)
 
         elif device_type == "SMOKE_DETECTOR":
             param_map = {
@@ -823,7 +823,7 @@ class CFASTParser:
                 },
             }
             device_params = self._extract_params(params, param_map)
-            device = Devices.create_smoke_detector(**device_params)
+            device = Device.create_smoke_detector(**device_params)
 
         elif device_type == "SPRINKLER":
             param_map = {
@@ -839,7 +839,7 @@ class CFASTParser:
                 },
             }
             device_params = self._extract_params(params, param_map)
-            device = Devices.create_sprinkler(**device_params)
+            device = Device.create_sprinkler(**device_params)
 
         else:
             raise ValueError(f"Unknown device type: {device_type}")
@@ -857,7 +857,7 @@ class CFASTParser:
                 "fraction": {"source": "F", "required": True, "type": float},
             }
             conn_params = self._extract_params(params, param_map)
-            surface_connection = SurfaceConnections.wall_connection(**conn_params)
+            surface_connection = SurfaceConnection.wall_connection(**conn_params)
 
         elif conn_type == "FLOOR":
             param_map = {
@@ -865,7 +865,7 @@ class CFASTParser:
                 "comp_ids": {"source": "COMP_IDS", "required": True, "type": str},
             }
             conn_params = self._extract_params(params, param_map)
-            surface_connection = SurfaceConnections.ceiling_floor_connection(
+            surface_connection = SurfaceConnection.ceiling_floor_connection(
                 **conn_params
             )
 
@@ -995,7 +995,7 @@ def parse_cfast_file(
     --------
     >>> model = parse_cfast_file("simulation.in")
     >>> print(f"Title: {model.simulation_environment.title}")
-    >>> print(f"Compartments: {len(model.compartments)}")
+    >>> print(f"Compartment: {len(model.compartments)}")
     """
     parser = CFASTParser()
     return parser.parse_file(file_path, output_path)

--- a/src/pycfast/surface_connection.py
+++ b/src/pycfast/surface_connection.py
@@ -1,7 +1,7 @@
 """
 Surface connections module for CFAST simulations.
 
-This module provides the SurfaceConnections class for defining heat transfer
+This module provides the SurfaceConnection class for defining heat transfer
 between compartments through solid boundaries (walls, ceilings, and floors)
 by means of conduction.
 """
@@ -15,7 +15,7 @@ from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class SurfaceConnections:
+class SurfaceConnection:
     """
     Represents surface connections for heat transfer between compartments in CFAST.
 
@@ -95,12 +95,12 @@ class SurfaceConnections:
     Create a wall connection between two rooms:
 
     >>> # For 1mx1mx1m compartments sharing 1m² wall out of 4m² total wall area
-    >>> wall_conn_1to2 = SurfaceConnections.wall_connection(
+    >>> wall_conn_1to2 = SurfaceConnection.wall_connection(
     ...     comp_id="ROOM1",
     ...     comp_ids="ROOM2",
     ...     fraction=0.25  # 1m²/4m² = 0.25
     ... )
-    >>> wall_conn_2to1 = SurfaceConnections.wall_connection(
+    >>> wall_conn_2to1 = SurfaceConnection.wall_connection(
     ...     comp_id="ROOM2",
     ...     comp_ids="ROOM1",
     ...     fraction=0.25  # Bidirectional connection required
@@ -108,7 +108,7 @@ class SurfaceConnections:
 
     Create a floor/ceiling connection between stacked compartments:
 
-    >>> floor_conn = SurfaceConnections.ceiling_floor_connection(
+    >>> floor_conn = SurfaceConnection.ceiling_floor_connection(
     ...     comp_id="UPPER_ROOM",    # Top compartment
     ...     comp_ids="LOWER_ROOM"    # Bottom compartment
     ... )
@@ -118,8 +118,8 @@ class SurfaceConnections:
     >>> # Compartment 1: 1x1x1m, Compartment 2: 2x2x2m
     >>> # Connection 1→2: 1m²/4m² = 0.25
     >>> # Connection 2→1: 1m²/16m² = 0.125 (same 1m² area, different base)
-    >>> conn_1to2 = SurfaceConnections.wall_connection("COMP1", "COMP2", 0.25)
-    >>> conn_2to1 = SurfaceConnections.wall_connection("COMP2", "COMP1", 0.125)
+    >>> conn_1to2 = SurfaceConnection.wall_connection("COMP1", "COMP2", 0.25)
+    >>> conn_2to1 = SurfaceConnection.wall_connection("COMP2", "COMP1", 0.125)
     """
 
     def __init__(
@@ -147,30 +147,30 @@ class SurfaceConnections:
         valid_types = {"WALL", "FLOOR"}
         if self.conn_type not in valid_types:
             raise ValueError(
-                f"SurfaceConnections: conn_type='{self.conn_type}' must be one of {valid_types}."
+                f"SurfaceConnection: conn_type='{self.conn_type}' must be one of {valid_types}."
             )
 
         if self.conn_type == "WALL":
             if self.fraction is None:
                 raise ValueError(
-                    "SurfaceConnections: WALL connection requires a fraction value."
+                    "SurfaceConnection: WALL connection requires a fraction value."
                 )
             if not 0.0 <= self.fraction <= 1.0:
                 raise ValueError(
-                    f"SurfaceConnections: fraction={self.fraction} must be in [0, 1] for WALL connections."
+                    f"SurfaceConnection: fraction={self.fraction} must be in [0, 1] for WALL connections."
                 )
 
         if self.conn_type == "FLOOR" and self.fraction is not None:
             warnings.warn(
-                "SurfaceConnections: fraction should be None for FLOOR connections.",
+                "SurfaceConnection: fraction should be None for FLOOR connections.",
                 UserWarning,
                 stacklevel=2,
             )
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the SurfaceConnections."""
+        """Return a detailed string representation of the SurfaceConnection."""
         return (
-            f"SurfaceConnections("
+            f"SurfaceConnection("
             f"conn_type='{self.conn_type}', "
             f"comp_id='{self.comp_id}', "
             f"comp_ids='{self.comp_ids}', "
@@ -179,7 +179,7 @@ class SurfaceConnections:
         )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the SurfaceConnections."""
+        """Return a user-friendly string representation of the SurfaceConnection."""
         connection = f"{self.comp_id} -> {self.comp_ids}"
         return f"Surface Connection ({self.conn_type}): {connection}"
 
@@ -226,7 +226,7 @@ class SurfaceConnections:
     def __getitem__(self, key: str) -> Any:
         """Get property by name for dictionary-like access."""
         if not hasattr(self, key):
-            raise KeyError(f"Property '{key}' not found in SurfaceConnections.")
+            raise KeyError(f"Property '{key}' not found in SurfaceConnection.")
         return getattr(self, key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -244,7 +244,7 @@ class SurfaceConnections:
         """
         if not hasattr(self, key):
             raise KeyError(
-                f"Cannot set '{key}'. Property does not exist in SurfaceConnections."
+                f"Cannot set '{key}'. Property does not exist in SurfaceConnection."
             )
         old_value = getattr(self, key)
         setattr(self, key, value)
@@ -265,11 +265,11 @@ class SurfaceConnections:
 
         Examples
         --------
-        >>> wall_conn = SurfaceConnections.wall_connection("ROOM1", "ROOM2", 0.25)
+        >>> wall_conn = SurfaceConnection.wall_connection("ROOM1", "ROOM2", 0.25)
         >>> print(wall_conn.to_input_string())
         &CONN TYPE = 'WALL' COMP_ID = 'ROOM1' COMP_IDS = 'ROOM2' F = 0.25 /
 
-        >>> floor_conn = SurfaceConnections.ceiling_floor_connection("UPPER", "LOWER")
+        >>> floor_conn = SurfaceConnection.ceiling_floor_connection("UPPER", "LOWER")
         >>> print(floor_conn.to_input_string())
         &CONN TYPE = 'FLOOR' COMP_ID = 'UPPER' COMP_IDS = 'LOWER' /
         """
@@ -286,7 +286,7 @@ class SurfaceConnections:
     @classmethod
     def wall_connection(
         cls, comp_id: str, comp_ids: str, fraction: float
-    ) -> SurfaceConnections:
+    ) -> SurfaceConnection:
         """
         Create a surface connection for horizontal heat transfer through walls.
 
@@ -304,7 +304,7 @@ class SurfaceConnections:
 
         Returns
         -------
-        SurfaceConnections
+        SurfaceConnection
             Configured surface connection instance for wall heat transfer.
         """
         return cls(
@@ -312,9 +312,7 @@ class SurfaceConnections:
         )
 
     @classmethod
-    def ceiling_floor_connection(
-        cls, comp_id: str, comp_ids: str
-    ) -> SurfaceConnections:
+    def ceiling_floor_connection(cls, comp_id: str, comp_ids: str) -> SurfaceConnection:
         """
         Create a surface connection for vertical heat transfer through floors/ceilings.
 
@@ -335,7 +333,7 @@ class SurfaceConnections:
 
         Returns
         -------
-        SurfaceConnections
+        SurfaceConnection
             Configured surface connection instance for floor/ceiling heat transfer.
         """
         return cls(conn_type="FLOOR", comp_id=comp_id, comp_ids=comp_ids, fraction=None)

--- a/src/pycfast/wall_vent.py
+++ b/src/pycfast/wall_vent.py
@@ -1,7 +1,7 @@
 """
 Wall vent definition module for CFAST simulations.
 
-This module provides the WallVents class for defining openings in walls
+This module provides the WallVent class for defining openings in walls
 that connect compartments horizontally, such as doors, windows, and openings.
 """
 
@@ -14,7 +14,7 @@ from .utils.namelist import NamelistRecord
 from .utils.theme import build_card
 
 
-class WallVents:
+class WallVent:
     """
     Represents wall openings connecting two compartments that physically overlap in elevation.
 
@@ -91,7 +91,7 @@ class WallVents:
     --------
     Create a door between two rooms following CFAST conventions:
 
-    >>> door = WallVents(
+    >>> door = WallVent(
     ...     id="DOOR_1_2",
     ...     comps_ids=["ROOM1", "ROOM2"],
     ...     bottom=0,           # Bottom at floor level (relative to first)
@@ -165,7 +165,7 @@ class WallVents:
         ):
             if val is not None and val < 0:
                 raise ValueError(
-                    f"WallVents '{self.id}': {dim} must be non-negative, got {val}."
+                    f"WallVent '{self.id}': {dim} must be non-negative, got {val}."
                 )
 
         for label, val in (
@@ -174,30 +174,30 @@ class WallVents:
         ):
             if val is not None and not 0.0 <= val <= 1.0:
                 raise ValueError(
-                    f"WallVents '{self.id}': {label}={val} must be in [0, 1]."
+                    f"WallVent '{self.id}': {label}={val} must be in [0, 1]."
                 )
 
         if self.fraction is not None:
             for i, f in enumerate(self.fraction):
                 if not 0.0 <= f <= 1.0:
                     raise ValueError(
-                        f"WallVents '{self.id}': fraction[{i}]={f} must be in [0, 1]."
+                        f"WallVent '{self.id}': fraction[{i}]={f} must be in [0, 1]."
                     )
 
         if (self.height is not None and self.height == 0) or (
             self.width is not None and self.width == 0
         ):
             warnings.warn(
-                f"WallVents '{self.id}': height or width is 0, meaning no flow will occur "
+                f"WallVent '{self.id}': height or width is 0, meaning no flow will occur "
                 "through this vent.",
                 UserWarning,
                 stacklevel=2,
             )
 
     def __repr__(self) -> str:
-        """Return a detailed string representation of the WallVents."""
+        """Return a detailed string representation of the WallVent."""
         return (
-            f"WallVents("
+            f"WallVent("
             f"id='{self.id}', "
             f"comps_ids={self.comps_ids}, "
             f"bottom={self.bottom}, height={self.height}, width={self.width}, "
@@ -206,7 +206,7 @@ class WallVents:
         )
 
     def __str__(self) -> str:
-        """Return a user-friendly string representation of the WallVents."""
+        """Return a user-friendly string representation of the WallVent."""
         connection = f"{self.comps_ids[0]} ↔ {self.comps_ids[1]}"
         size_info = f"{self.width}x{self.height} m"
         position_info = f"bottom: {self.bottom} m"
@@ -245,7 +245,7 @@ class WallVents:
     def __getitem__(self, key: str) -> Any:
         """Get vent property by name for dictionary-like access."""
         if not hasattr(self, key):
-            raise KeyError(f"Property '{key}' not found in WallVents.")
+            raise KeyError(f"Property '{key}' not found in WallVent.")
         return getattr(self, key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -262,7 +262,7 @@ class WallVents:
             If setting this value would violate object constraints.
         """
         if not hasattr(self, key):
-            raise KeyError(f"Cannot set '{key}'. Property does not exist in WallVents.")
+            raise KeyError(f"Cannot set '{key}'. Property does not exist in WallVent.")
         old_value = getattr(self, key)
         setattr(self, key, value)
         try:
@@ -282,7 +282,7 @@ class WallVents:
 
         Examples
         --------
-        >>> vent = WallVents("DOOR1", ["RM1", "RM2"], 0.0, 2.0, 0.9, "RIGHT", 1.0)
+        >>> vent = WallVent("DOOR1", ["RM1", "RM2"], 0.0, 2.0, 0.9, "RIGHT", 1.0)
         >>> print(vent.to_input_string())
         &VENT TYPE = 'WALL' ID = 'DOOR1' COMP_IDS = 'RM1', 'RM2' BOTTOM = 0.0 ...
         """

--- a/tests/units/test_ceiling_floor_vent.py
+++ b/tests/units/test_ceiling_floor_vent.py
@@ -2,35 +2,35 @@ from __future__ import annotations
 
 import pytest
 
-from pycfast.ceiling_floor_vents import CeilingFloorVents
+from pycfast.ceiling_floor_vent import CeilingFloorVent
 
 """
-Tests for the CeilingFloorVents class.
+Tests for the CeilingFloorVent class.
 """
 
 
 @pytest.fixture()
 def make_ceiling_floor_vent():
-    """Create a CeilingFloorVents instance with sensible defaults."""
+    """Create a CeilingFloorVent instance with sensible defaults."""
 
-    def _make(**kwargs: object) -> CeilingFloorVents:
+    def _make(**kwargs: object) -> CeilingFloorVent:
         defaults: dict[str, object] = {
             "id": "VENT1",
             "comps_ids": ["UPPER", "LOWER"],
             "area": 1.0,
         }
         defaults.update(kwargs)
-        return CeilingFloorVents(**defaults)  # type: ignore[arg-type]
+        return CeilingFloorVent(**defaults)  # type: ignore[arg-type]
 
     return _make
 
 
-class TestCeilingFloorVents:
-    """Test class for CeilingFloorVents."""
+class TestCeilingFloorVent:
+    """Test class for CeilingFloorVent."""
 
     def test_init_basic(self):
         """Test basic initialization with required parameters."""
-        vent = CeilingFloorVents(id="VENT1", comps_ids=["UPPER", "LOWER"], area=1.0)
+        vent = CeilingFloorVent(id="VENT1", comps_ids=["UPPER", "LOWER"], area=1.0)
         assert vent.id == "VENT1"
         assert vent.comps_ids == ["UPPER", "LOWER"]
         assert vent.area == 1.0
@@ -40,7 +40,7 @@ class TestCeilingFloorVents:
 
     def test_init_with_all_parameters(self):
         """Test initialization with all parameters."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="VENT1",
             comps_ids=["UPPER", "LOWER"],
             area=2.5,
@@ -79,12 +79,12 @@ class TestCeilingFloorVents:
     def test_init_invalid_comps_ids_length(self, comps_ids: list[str]):
         """Test that initialization fails with wrong number of compartments."""
         with pytest.raises(ValueError, match="exactly 2 compartments"):
-            CeilingFloorVents(id="VENT1", comps_ids=comps_ids, area=1.0)
+            CeilingFloorVent(id="VENT1", comps_ids=comps_ids, area=1.0)
 
     def test_init_mismatched_time_fraction_lists(self):
         """Test that initialization fails with mismatched time and fraction lists."""
         with pytest.raises(ValueError, match="equal length"):
-            CeilingFloorVents(
+            CeilingFloorVent(
                 id="VENT1",
                 comps_ids=["UPPER", "LOWER"],
                 area=1.0,
@@ -95,7 +95,7 @@ class TestCeilingFloorVents:
     def test_area_negative_values(self):
         """Test that negative area values are rejected."""
         with pytest.raises(ValueError, match="area must be non-negative"):
-            CeilingFloorVents(id="VENT1", comps_ids=["UPPER", "LOWER"], area=-1.0)
+            CeilingFloorVent(id="VENT1", comps_ids=["UPPER", "LOWER"], area=-1.0)
 
     @pytest.mark.parametrize(
         ("param", "value"),
@@ -107,7 +107,7 @@ class TestCeilingFloorVents:
     def test_pre_post_fraction_invalid_values(self, param, value):
         """Test that invalid pre/post_fraction values (out of [0, 1]) are rejected."""
         with pytest.raises(ValueError, match=r"must be in \[0, 1\]\."):
-            CeilingFloorVents(
+            CeilingFloorVent(
                 id="VENT1",
                 comps_ids=["UPPER", "LOWER"],
                 area=1.0,
@@ -118,7 +118,7 @@ class TestCeilingFloorVents:
     def test_fraction_invalid_values(self):
         """Test that invalid fracion value (out of [0, 1]) are rejected."""
         with pytest.raises(ValueError, match=r"must be in \[0, 1\]\."):
-            CeilingFloorVents(
+            CeilingFloorVent(
                 id="VENT1",
                 comps_ids=["UPPER", "LOWER"],
                 area=1.0,
@@ -130,11 +130,11 @@ class TestCeilingFloorVents:
         with pytest.warns(
             UserWarning, match="area=0 means no flow will occur through this vent"
         ):
-            CeilingFloorVents(id="VENT1", comps_ids=["UPPER", "LOWER"], area=0.0)
+            CeilingFloorVent(id="VENT1", comps_ids=["UPPER", "LOWER"], area=0.0)
 
     def test_to_input_string_basic(self):
         """Test basic input string generation."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="HOLE1", comps_ids=["RM_UP", "RM_LOW"], area=1.0, shape="ROUND"
         )
         result = vent.to_input_string()
@@ -149,7 +149,7 @@ class TestCeilingFloorVents:
 
     def test_to_input_string_with_offsets(self):
         """Test input string generation with custom offsets."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="VENT1",
             comps_ids=["UPPER", "LOWER"],
             area=2.0,
@@ -165,7 +165,7 @@ class TestCeilingFloorVents:
 
     def test_to_input_string_with_time_fraction(self):
         """Test input string generation with time and fraction data."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="VENT1",
             comps_ids=["UPPER", "LOWER"],
             area=1.0,
@@ -253,7 +253,7 @@ class TestCeilingFloorVents:
 
     def test_to_input_string_with_all_options(self):
         """Test input string generation with all possible options."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="COMPLEX_VENT",
             comps_ids=["TOP_ROOM", "BOTTOM_ROOM"],
             area=3.14,
@@ -287,14 +287,14 @@ class TestCeilingFloorVents:
 
     def test_default_offsets(self):
         """Test that default offsets are set when None is provided."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="VENT1", comps_ids=["UPPER", "LOWER"], area=1.0, offsets=None
         )
         assert vent.offsets == [0, 0]
 
     def test_compartment_ids_formatting(self):
         """Test that compartment IDs are properly quoted in output."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="TEST_VENT", comps_ids=["COMP_1", "COMP_2"], area=1.0
         )
         result = vent.to_input_string()
@@ -302,7 +302,7 @@ class TestCeilingFloorVents:
 
     def test_repr(self):
         """Test __repr__ method."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="STAIR_VENT",
             comps_ids=["UPPER_FLOOR", "LOWER_FLOOR"],
             area=2.0,
@@ -312,7 +312,7 @@ class TestCeilingFloorVents:
         )
 
         repr_str = repr(vent)
-        assert "CeilingFloorVents(" in repr_str
+        assert "CeilingFloorVent(" in repr_str
         assert "id='STAIR_VENT'" in repr_str
         assert "comps_ids=['UPPER_FLOOR', 'LOWER_FLOOR']" in repr_str
         assert "area=2.0" in repr_str
@@ -322,7 +322,7 @@ class TestCeilingFloorVents:
 
     def test_str(self):
         """Test __str__ method."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="STAIR_OPENING",
             comps_ids=["UPPER_ROOM", "LOWER_ROOM"],
             area=3.5,
@@ -339,7 +339,7 @@ class TestCeilingFloorVents:
 
     def test_str_with_criterion(self):
         """Test __str__ method with opening criterion."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="CONTROLLED_VENT",
             comps_ids=["UP", "DOWN"],
             area=1.0,
@@ -355,7 +355,7 @@ class TestCeilingFloorVents:
 
     def test_getitem(self) -> None:
         """Test __getitem__ method."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="TEST_VENT",
             comps_ids=["ROOM1", "ROOM2"],
             area=2.5,
@@ -373,16 +373,16 @@ class TestCeilingFloorVents:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        vent = CeilingFloorVents(id="VENT1", comps_ids=["UP", "DOWN"], area=1.0)
+        vent = CeilingFloorVent(id="VENT1", comps_ids=["UP", "DOWN"], area=1.0)
 
         with pytest.raises(
-            KeyError, match="Property 'invalid_key' not found in CeilingFloorVents"
+            KeyError, match="Property 'invalid_key' not found in CeilingFloorVent"
         ):
             vent["invalid_key"]
 
     def test_setitem(self) -> None:
         """Test __setitem__ method."""
-        vent = CeilingFloorVents(id="VENT1", comps_ids=["UP", "DOWN"], area=1.0)
+        vent = CeilingFloorVent(id="VENT1", comps_ids=["UP", "DOWN"], area=1.0)
 
         vent["id"] = "NEW_VENT"
         assert vent.id == "NEW_VENT"
@@ -398,14 +398,14 @@ class TestCeilingFloorVents:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        vent = CeilingFloorVents(id="VENT1", comps_ids=["UP", "DOWN"], area=1.0)
+        vent = CeilingFloorVent(id="VENT1", comps_ids=["UP", "DOWN"], area=1.0)
 
         with pytest.raises(KeyError, match="Cannot set 'invalid_key'"):
             vent["invalid_key"] = "value"
 
     def test_repr_html(self) -> None:
         """Test _repr_html_ method."""
-        vent = CeilingFloorVents(
+        vent = CeilingFloorVent(
             id="STAIR_VENT",
             comps_ids=["UPPER_FLOOR", "LOWER_FLOOR"],
             area=2.0,
@@ -431,7 +431,7 @@ class TestCeilingFloorVents:
         assert "1.4" in html_str
 
 
-class TestCeilingFloorVentsSetItemValidation:
+class TestCeilingFloorVentSetItemValidation:
     """Test validation in __setitem__ to ensure data integrity."""
 
     @pytest.mark.parametrize(

--- a/tests/units/test_compartment.py
+++ b/tests/units/test_compartment.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import pytest
 
-from pycfast.compartments import Compartments
+from pycfast.compartment import Compartment
 
 """
-Tests for the Compartments class.
+Tests for the Compartment class.
 """
 
 
-class TestCompartments:
-    """Test class for Compartments."""
+class TestCompartment:
+    """Test class for Compartment."""
 
     def test_init_default(self):
         """Test default initialization."""
-        comp = Compartments()
+        comp = Compartment()
         assert comp.id == "Comp 1"
         assert comp.width == 3.6
         assert comp.depth == 2.4
@@ -33,7 +33,7 @@ class TestCompartments:
 
     def test_init_with_all_parameters(self):
         """Test initialization with all parameters."""
-        comp = Compartments(
+        comp = Compartment(
             id="BEDROOM",
             width=3.5,
             depth=4.0,
@@ -75,12 +75,12 @@ class TestCompartments:
     def test_init_shaft_and_hall_both_true(self):
         """Test that initialization fails when both shaft and hall are True."""
         with pytest.raises(ValueError, match="shaft and hall cannot both be True"):
-            Compartments(id="ROOM1", shaft=True, hall=True)
+            Compartment(id="ROOM1", shaft=True, hall=True)
 
     def test_init_mismatched_cross_sect_arrays(self):
         """Test that initialization fails with mismatched cross-section arrays."""
         with pytest.raises(ValueError, match="must have the same length"):
-            Compartments(
+            Compartment(
                 id="ROOM1",
                 cross_sect_areas=[10.0, 15.0],
                 cross_sect_heights=[1.0],
@@ -96,23 +96,23 @@ class TestCompartments:
     def test_init_invalid_leak_area_ratio_length(self, leak_area_ratio: list[float]):
         """Test that initialization fails with wrong leak area ratio length."""
         with pytest.raises(ValueError, match="must contain exactly 2 values"):
-            Compartments(id="ROOM1", leak_area_ratio=leak_area_ratio)
+            Compartment(id="ROOM1", leak_area_ratio=leak_area_ratio)
 
     @pytest.mark.parametrize("param", ["width", "depth", "height"])
     def test_negative_dimension(self, param: str):
         """Test that initialization fails with negative dimensions."""
         with pytest.raises(ValueError, match="must be positive"):
-            Compartments(id="ROOM1", **{param: -1.0})  # type: ignore[arg-type]
+            Compartment(id="ROOM1", **{param: -1.0})  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("param", ["origin_x", "origin_y", "origin_z"])
     def test_negative_location(self, param: str):
         """Test that initialization fails with negative origin coordinates."""
         with pytest.raises(ValueError, match=r"must be >= 0"):
-            Compartments(id="ROOM1", width=3.0, depth=4.0, height=2.4, **{param: -1.0})  # type: ignore[arg-type]
+            Compartment(id="ROOM1", width=3.0, depth=4.0, height=2.4, **{param: -1.0})  # type: ignore[arg-type]
 
     def test_to_input_string_basic(self):
         """Test basic input string generation."""
-        comp = Compartments(id="ROOM1", width=3.0, depth=4.0, height=2.4)
+        comp = Compartment(id="ROOM1", width=3.0, depth=4.0, height=2.4)
         result = comp.to_input_string()
         assert result.startswith("&COMP")
         assert result.endswith("/\n")
@@ -125,7 +125,7 @@ class TestCompartments:
 
     def test_to_input_string_with_materials(self):
         """Test input string generation with materials."""
-        comp = Compartments(
+        comp = Compartment(
             id="ROOM1",
             width=3.0,
             depth=4.0,
@@ -180,14 +180,14 @@ class TestCompartments:
         self, prop: str, kwargs: dict, expected: str, unexpected: str
     ):
         """Test input string generation with shaft or hall option."""
-        comp = Compartments(**kwargs)  # type: ignore[arg-type]
+        comp = Compartment(**kwargs)  # type: ignore[arg-type]
         result = comp.to_input_string()
         assert expected in result
         assert unexpected not in result
 
     def test_to_input_string_with_cross_sections(self):
         """Test input string generation with variable cross-sections."""
-        comp = Compartments(
+        comp = Compartment(
             id="ROOM1",
             width=3.0,
             depth=4.0,
@@ -201,7 +201,7 @@ class TestCompartments:
 
     def test_to_input_string_with_leak_area_ratio(self):
         """Test input string generation with leak area ratios."""
-        comp = Compartments(
+        comp = Compartment(
             id="ROOM1",
             width=3.0,
             depth=4.0,
@@ -213,7 +213,7 @@ class TestCompartments:
 
     def test_to_input_string_custom_origin(self):
         """Test input string generation with custom origin."""
-        comp = Compartments(
+        comp = Compartment(
             id="ROOM2",
             width=3.0,
             depth=4.0,
@@ -227,7 +227,7 @@ class TestCompartments:
 
     def test_to_input_string_partial_origin(self):
         """Test input string generation with partial origin specification."""
-        comp = Compartments(
+        comp = Compartment(
             id="ROOM2",
             width=3.0,
             depth=4.0,
@@ -241,7 +241,7 @@ class TestCompartments:
 
     def test_to_input_string_materials_without_thickness(self):
         """Test input string generation with materials but without thickness."""
-        comp = Compartments(
+        comp = Compartment(
             id="ROOM1",
             width=3.0,
             depth=4.0,
@@ -260,7 +260,7 @@ class TestCompartments:
 
     def test_to_input_string_none_dimensions(self):
         """Test input string generation with None dimensions."""
-        comp = Compartments(id="ROOM1", width=None, depth=None, height=None)
+        comp = Compartment(id="ROOM1", width=None, depth=None, height=None)
         result = comp.to_input_string()
         assert "WIDTH" not in result
         assert "DEPTH" not in result
@@ -268,20 +268,20 @@ class TestCompartments:
 
     def test_init_cross_sect_areas_only(self):
         """Test initialization with cross_sect_areas but no heights."""
-        comp = Compartments(id="ROOM1", cross_sect_areas=[10.0, 15.0])
+        comp = Compartment(id="ROOM1", cross_sect_areas=[10.0, 15.0])
         assert comp.cross_sect_areas == [10.0, 15.0]
         assert comp.cross_sect_heights is None
 
     def test_init_cross_sect_heights_only(self):
         """Test initialization with cross_sect_heights but no areas."""
-        comp = Compartments(id="ROOM1", cross_sect_heights=[1.0, 2.0])
+        comp = Compartment(id="ROOM1", cross_sect_heights=[1.0, 2.0])
         assert comp.cross_sect_heights == [1.0, 2.0]
         assert comp.cross_sect_areas is None
 
     # Tests for dunder methods
     def test_repr(self) -> None:
         """Test __repr__ method."""
-        comp = Compartments(
+        comp = Compartment(
             id="BEDROOM",
             width=3.5,
             depth=4.0,
@@ -291,7 +291,7 @@ class TestCompartments:
         )
 
         repr_str = repr(comp)
-        assert "Compartments(" in repr_str
+        assert "Compartment(" in repr_str
         assert "id='BEDROOM'" in repr_str
         assert "width=3.5" in repr_str
         assert "depth=4.0" in repr_str
@@ -299,7 +299,7 @@ class TestCompartments:
 
     def test_str(self) -> None:
         """Test __str__ method."""
-        comp = Compartments(
+        comp = Compartment(
             id="LIVING_ROOM",
             width=5.0,
             depth=4.0,
@@ -317,7 +317,7 @@ class TestCompartments:
 
     def test_str_with_shaft_and_hall(self) -> None:
         """Test __str__ method with shaft property only."""
-        comp = Compartments(
+        comp = Compartment(
             id="CORRIDOR",
             width=2.0,
             depth=10.0,
@@ -332,7 +332,7 @@ class TestCompartments:
 
     def test_getitem(self) -> None:
         """Test __getitem__ method."""
-        comp = Compartments(
+        comp = Compartment(
             id="TEST_ROOM",
             width=4.0,
             depth=3.0,
@@ -360,7 +360,7 @@ class TestCompartments:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        comp = Compartments(id="ROOM1")
+        comp = Compartment(id="ROOM1")
 
         with pytest.raises(
             KeyError, match="Property 'invalid_key' not found in Compartment"
@@ -369,7 +369,7 @@ class TestCompartments:
 
     def test_setitem(self) -> None:
         """Test __setitem__ method."""
-        comp = Compartments(id="ROOM1")
+        comp = Compartment(id="ROOM1")
 
         # Test setting various properties
         comp["id"] = "NEW_ROOM"
@@ -404,7 +404,7 @@ class TestCompartments:
 
     def test_setitem_list_properties(self) -> None:
         """Test __setitem__ method with list properties."""
-        comp = Compartments(id="ROOM1")
+        comp = Compartment(id="ROOM1")
 
         comp["leak_area_ratio"] = [0.001, 0.002]
         assert comp.leak_area_ratio == [0.001, 0.002]
@@ -417,14 +417,14 @@ class TestCompartments:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        comp = Compartments(id="ROOM1")
+        comp = Compartment(id="ROOM1")
 
         with pytest.raises(KeyError, match="Cannot set 'invalid_key'"):
             comp["invalid_key"] = "value"
 
     def test_repr_html(self) -> None:
         """Test _repr_html_ method."""
-        comp = Compartments(
+        comp = Compartment(
             id="BEDROOM",
             width=3.5,
             depth=4.0,
@@ -463,7 +463,7 @@ class TestCompartments:
 
     def test_repr_html_with_special_properties(self) -> None:
         """Test _repr_html_ method with shaft/hall properties."""
-        comp_shaft = Compartments(
+        comp_shaft = Compartment(
             id="SHAFT1", shaft=True, width=2.0, depth=2.0, height=10.0
         )
 
@@ -472,7 +472,7 @@ class TestCompartments:
         assert "Shaft" in html_str
         assert "<strong>Type:</strong> Shaft" in html_str
 
-        comp_hall = Compartments(
+        comp_hall = Compartment(
             id="HALL1", hall=True, width=10.0, depth=2.0, height=2.4
         )
 
@@ -483,19 +483,19 @@ class TestCompartments:
 
     def test_repr_html_no_materials(self) -> None:
         """Test _repr_html_ method with no materials specified."""
-        comp = Compartments(id="EMPTY", width=3.0, depth=3.0, height=3.0)
+        comp = Compartment(id="EMPTY", width=3.0, depth=3.0, height=3.0)
 
         html_str = comp._repr_html_()
 
         assert "<em>No materials specified</em>" in html_str
 
 
-class TestCompartmentsSetItemValidation:
+class TestCompartmentSetItemValidation:
     """Test validation in __setitem__ to ensure data integrity."""
 
     def test_setitem_shaft_and_hall_both_true(self):
         """Test that __setitem__ rejects shaft and hall both True."""
-        comp = Compartments(id="ROOM1", shaft=True)
+        comp = Compartment(id="ROOM1", shaft=True)
         with pytest.raises(ValueError, match="shaft and hall cannot both be True"):
             comp["hall"] = True
 
@@ -508,7 +508,7 @@ class TestCompartmentsSetItemValidation:
     )
     def test_setitem_invalid_leak_area_ratio_length(self, invalid_ratio):
         """Test that __setitem__ rejects leak_area_ratio with wrong length."""
-        comp = Compartments(id="ROOM1")
+        comp = Compartment(id="ROOM1")
         with pytest.raises(
             ValueError, match="leak_area_ratio must contain exactly 2 values"
         ):
@@ -516,7 +516,7 @@ class TestCompartmentsSetItemValidation:
 
     def test_setitem_mismatched_cross_sect_lengths(self):
         """Test that __setitem__ rejects mismatched cross section list lengths."""
-        comp = Compartments(
+        comp = Compartment(
             id="ROOM1",
             cross_sect_areas=[1.0, 2.0],
             cross_sect_heights=[0.0, 1.0],
@@ -529,7 +529,7 @@ class TestCompartmentsSetItemValidation:
 
     def test_setitem_valid_dimension_changes(self):
         """Test that __setitem__ accepts valid dimension changes."""
-        comp = Compartments(id="ROOM1")
+        comp = Compartment(id="ROOM1")
         comp["width"] = 5.0
         comp["height"] = 3.0
         assert comp.width == 5.0
@@ -537,7 +537,7 @@ class TestCompartmentsSetItemValidation:
 
     def test_setitem_invalid_does_not_mutate_state(self):
         """Test that a failed __setitem__ rolls back to the previous value."""
-        comp = Compartments(id="ROOM1", shaft=True)
+        comp = Compartment(id="ROOM1", shaft=True)
         assert comp.shaft is True
         assert comp.hall is None
 

--- a/tests/units/test_device.py
+++ b/tests/units/test_device.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import pytest
 
-from pycfast.devices import Devices
+from pycfast.device import Device
 
 """
-Tests for the Devices class.
+Tests for the Device class.
 """
 
 
-class TestDevices:
-    """Test class for Devices."""
+class TestDevice:
+    """Test class for Device."""
 
     def test_init_plate_target(self):
         """Test initialization of a PLATE target device."""
-        device = Devices(
+        device = Device(
             id="TARGET1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -38,7 +38,7 @@ class TestDevices:
 
     def test_init_cylinder_target(self):
         """Test initialization of a CYLINDER target device."""
-        device = Devices(
+        device = Device(
             id="TARGET2",
             comp_id="ROOM1",
             location=[2.0, 3.0, 2.0],
@@ -56,7 +56,7 @@ class TestDevices:
 
     def test_init_heat_detector(self):
         """Test initialization of a HEAT_DETECTOR device."""
-        device = Devices(
+        device = Device(
             id="HD1",
             comp_id="ROOM1",
             location=[1.5, 1.5, 2.3],
@@ -72,7 +72,7 @@ class TestDevices:
 
     def test_init_smoke_detector(self):
         """Test initialization of a SMOKE_DETECTOR device."""
-        device = Devices(
+        device = Device(
             id="SD1",
             comp_id="ROOM1",
             location=[2.0, 2.0, 2.3],
@@ -86,7 +86,7 @@ class TestDevices:
 
     def test_init_sprinkler(self):
         """Test initialization of a SPRINKLER device."""
-        device = Devices(
+        device = Device(
             id="SPR1",
             comp_id="ROOM1",
             location=[3.0, 3.0, 2.4],
@@ -105,7 +105,7 @@ class TestDevices:
     def test_init_invalid_location_length(self):
         """Test that initialization fails with wrong location dimensions."""
         with pytest.raises(ValueError, match="location must be a list of 3 numbers"):
-            Devices(
+            Device(
                 id="DEV1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0],  # Only 2 coordinates
@@ -120,7 +120,7 @@ class TestDevices:
         with pytest.raises(ValueError, match="location must be a list of 3 numbers"):
             # This should fail validation even though it passes type checking temporarily
             invalid_location = [1.0, "invalid", 1.5]  # type: ignore
-            Devices(
+            Device(
                 id="DEV1",
                 comp_id="ROOM1",
                 location=invalid_location,
@@ -133,7 +133,7 @@ class TestDevices:
     def test_init_target_missing_material_id(self):
         """Test that target initialization fails without material_id."""
         with pytest.raises(ValueError, match="requires material_id"):
-            Devices(
+            Device(
                 id="TARGET1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0, 1.5],
@@ -145,7 +145,7 @@ class TestDevices:
 
     def test_init_target_with_default_temperature_depth(self):
         """Test that target initialization uses default temperature_depth when not specified."""
-        device = Devices(
+        device = Device(
             id="TARGET1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -160,7 +160,7 @@ class TestDevices:
     def test_init_target_both_normal_and_orientation(self):
         """Test that target initialization fails with both normal and surface_orientation."""
         with pytest.raises(ValueError, match="either normal or surface_orientation"):
-            Devices(
+            Device(
                 id="TARGET1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0, 1.5],
@@ -174,7 +174,7 @@ class TestDevices:
     def test_init_target_neither_normal_nor_orientation(self):
         """Test that target initialization fails without normal or surface_orientation."""
         with pytest.raises(ValueError, match="either normal or surface_orientation"):
-            Devices(
+            Device(
                 id="TARGET1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0, 1.5],
@@ -187,7 +187,7 @@ class TestDevices:
     def test_init_target_invalid_normal(self):
         """Test that target initialization fails with invalid normal vector."""
         with pytest.raises(ValueError, match="normal must be a list of 3 numbers"):
-            Devices(
+            Device(
                 id="TARGET1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0, 1.5],
@@ -200,7 +200,7 @@ class TestDevices:
     def test_init_invalid_temperature_depth(self):
         """Test that target initialization fails with invalid temperature_depth."""
         with pytest.raises(ValueError, match=r"must be in \[0, 1\]\."):
-            Devices(
+            Device(
                 id="TARGET1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0, 1.5],
@@ -222,7 +222,7 @@ class TestDevices:
     def test_init_rti_zero_or_negative(self, device_type: str, extra_kwargs: dict):
         """Test that detector/sprinkler initialization fails with zero or negative RTI."""
         with pytest.raises(ValueError, match="rti must be positive"):
-            Devices(
+            Device(
                 id="D1",
                 comp_id="ROOM1",
                 location=[1.5, 1.5, 2.3],
@@ -244,7 +244,7 @@ class TestDevices:
     def test_init_setpoint_zero_or_negative(self, device_type: str, extra_kwargs: dict):
         """Test that detector/sprinkler initialization fails with zero or negative setpoint."""
         with pytest.raises(ValueError, match="setpoint must be positive"):
-            Devices(
+            Device(
                 id="D1",
                 comp_id="ROOM1",
                 location=[1.5, 1.5, 2.3],
@@ -257,7 +257,7 @@ class TestDevices:
     def test_init_sprinkler_spray_density_zero_or_negative(self):
         """Test that sprinkler initialization fails with zero or negative spray density."""
         with pytest.raises(ValueError, match="spray_density must be positive"):
-            Devices(
+            Device(
                 id="HD1",
                 comp_id="ROOM1",
                 location=[1.5, 1.5, 2.3],
@@ -271,7 +271,7 @@ class TestDevices:
     def test_init_smoke_detector_invalid_obscuration_value(self):
         """Test that smoke detector initialization fails with invalid obscuration value (out of [0, 100])."""
         with pytest.warns(UserWarning, match="This may cause inaccurate results"):
-            Devices(
+            Device(
                 id="SD1",
                 comp_id="ROOM1",
                 location=[2.0, 2.0, 2.3],
@@ -283,7 +283,7 @@ class TestDevices:
     def test_init_heat_detector_missing_parameters(self):
         """Test that heat detector initialization fails without required parameters."""
         with pytest.raises(ValueError, match="HEAT_DETECTOR requires setpoint and rti"):
-            Devices(
+            Device(
                 id="HD1",
                 comp_id="ROOM1",
                 location=[1.5, 1.5, 2.3],
@@ -295,7 +295,7 @@ class TestDevices:
 
     def test_init_smoke_detector_with_default_obscuration(self):
         """Test that smoke detector initialization uses default obscuration when not specified."""
-        device = Devices(
+        device = Device(
             id="SD1",
             comp_id="ROOM1",
             location=[2.0, 2.0, 2.3],
@@ -311,7 +311,7 @@ class TestDevices:
         with pytest.raises(
             ValueError, match="SPRINKLER requires setpoint, rti, and spray_density"
         ):
-            Devices(
+            Device(
                 id="SPR1",
                 comp_id="ROOM1",
                 location=[3.0, 3.0, 2.4],
@@ -325,7 +325,7 @@ class TestDevices:
     def test_init_unknown_device_type(self):
         """Test that initialization fails with unknown device type."""
         with pytest.raises(ValueError, match="Unknown device type"):
-            Devices(
+            Device(
                 id="DEV1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0, 1.5],
@@ -335,7 +335,7 @@ class TestDevices:
 
     def test_to_input_string_plate_target_with_normal(self):
         """Test input string generation for plate target with normal vector."""
-        device = Devices(
+        device = Device(
             id="TARGET1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -365,7 +365,7 @@ class TestDevices:
 
     def test_to_input_string_plate_target_with_surface_orientation(self):
         """Test input string generation for plate target with surface orientation."""
-        device = Devices(
+        device = Device(
             id="TARGET2",
             comp_id="ROOM1",
             location=[2.0, 3.0, 2.0],
@@ -380,7 +380,7 @@ class TestDevices:
 
     def test_to_input_string_heat_detector(self):
         """Test input string generation for heat detector."""
-        device = Devices(
+        device = Device(
             id="HD1",
             comp_id="ROOM1",
             location=[1.5, 1.5, 2.3],
@@ -402,7 +402,7 @@ class TestDevices:
 
     def test_to_input_string_smoke_detector(self):
         """Test input string generation for smoke detector."""
-        device = Devices(
+        device = Device(
             id="SD1",
             comp_id="ROOM1",
             location=[2.0, 2.0, 2.3],
@@ -416,7 +416,7 @@ class TestDevices:
 
     def test_to_input_string_sprinkler(self):
         """Test input string generation for sprinkler."""
-        device = Devices(
+        device = Device(
             id="SPR1",
             comp_id="ROOM1",
             location=[3.0, 3.0, 2.4],
@@ -438,7 +438,7 @@ class TestDevices:
 
     def test_to_input_string_with_adiabatic(self):
         """Test input string generation with adiabatic flag."""
-        device = Devices(
+        device = Device(
             id="DEV1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -454,7 +454,7 @@ class TestDevices:
 
     def test_to_input_string_with_convection_coefficients(self):
         """Test input string generation with convection coefficients."""
-        device = Devices(
+        device = Device(
             id="DEV2",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -471,7 +471,7 @@ class TestDevices:
     # Test class methods
     def test_create_target_classmethod(self):
         """Test the create_target class method."""
-        device = Devices.create_target(
+        device = Device.create_target(
             id="TARGET1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -481,7 +481,7 @@ class TestDevices:
             temperature_depth=0.0005,
             thickness=0.001,
         )
-        assert isinstance(device, Devices)
+        assert isinstance(device, Device)
         assert device.type == "PLATE"
         assert device.material_id == "STEEL"
         assert device.normal == [0, 0, -1]
@@ -489,7 +489,7 @@ class TestDevices:
     def test_create_target_classmethod_validation(self):
         """Test that create_target class method validates inputs."""
         with pytest.raises(ValueError, match="either normal or surface_orientation"):
-            Devices.create_target(
+            Device.create_target(
                 id="TARGET1",
                 comp_id="ROOM1",
                 location=[1.0, 2.0, 1.5],
@@ -552,16 +552,16 @@ class TestDevices:
         extra_checks: dict,
     ):
         """Test device creation class methods."""
-        method = getattr(Devices, factory_method)
+        method = getattr(Device, factory_method)
         device = method(**factory_kwargs)
-        assert isinstance(device, Devices)
+        assert isinstance(device, Device)
         assert device.type == expected_type
         for attr, value in extra_checks.items():
             assert getattr(device, attr) == value
 
     def test_repr_target(self):
         """Test __repr__ method for target device."""
-        device = Devices(
+        device = Device(
             id="TEMP_01",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -573,7 +573,7 @@ class TestDevices:
         )
 
         repr_str = repr(device)
-        assert "Devices(" in repr_str
+        assert "Device(" in repr_str
         assert "id='TEMP_01'" in repr_str
         assert "type='PLATE'" in repr_str
         assert "comp_id='ROOM1'" in repr_str
@@ -584,7 +584,7 @@ class TestDevices:
 
     def test_repr_detector(self):
         """Test __repr__ method for detector device."""
-        device = Devices.create_heat_detector(
+        device = Device.create_heat_detector(
             id="HD_01",
             comp_id="ROOM1",
             location=[2.0, 2.0, 2.4],
@@ -593,7 +593,7 @@ class TestDevices:
         )
 
         repr_str = repr(device)
-        assert "Devices(" in repr_str
+        assert "Device(" in repr_str
         assert "id='HD_01'" in repr_str
         assert "type='HEAT_DETECTOR'" in repr_str
         assert "setpoint=74.0" in repr_str
@@ -601,7 +601,7 @@ class TestDevices:
 
     def test_str_target(self):
         """Test __str__ method for target device."""
-        device = Devices(
+        device = Device(
             id="TEMP_01",
             comp_id="LIVING_ROOM",
             location=[1.0, 2.0, 1.5],
@@ -622,7 +622,7 @@ class TestDevices:
 
     def test_str_heat_detector(self):
         """Test __str__ method for heat detector."""
-        device = Devices.create_heat_detector(
+        device = Device.create_heat_detector(
             id="HD_01",
             comp_id="BEDROOM",
             location=[2.0, 2.0, 2.4],
@@ -639,7 +639,7 @@ class TestDevices:
 
     def test_str_smoke_detector(self):
         """Test __str__ method for smoke detector."""
-        device = Devices.create_smoke_detector(
+        device = Device.create_smoke_detector(
             id="SD_01",
             comp_id="HALLWAY",
             location=[3.0, 1.0, 2.4],
@@ -654,7 +654,7 @@ class TestDevices:
 
     def test_str_sprinkler(self):
         """Test __str__ method for sprinkler."""
-        device = Devices.create_sprinkler(
+        device = Device.create_sprinkler(
             id="SPR_01",
             comp_id="KITCHEN",
             location=[2.5, 2.5, 2.4],
@@ -675,7 +675,7 @@ class TestDevices:
 
     def test_getitem_target(self) -> None:
         """Test __getitem__ method for target device."""
-        device = Devices(
+        device = Device(
             id="TEMP_01",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -697,7 +697,7 @@ class TestDevices:
 
     def test_getitem_detector(self) -> None:
         """Test __getitem__ method for detector device."""
-        device = Devices.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
+        device = Device.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
 
         assert device["id"] == "HD1"
         assert device["setpoint"] == 70.0
@@ -706,16 +706,16 @@ class TestDevices:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        device = Devices.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
+        device = Device.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
 
         with pytest.raises(
-            KeyError, match="Property 'invalid_key' not found in Devices"
+            KeyError, match="Property 'invalid_key' not found in Device"
         ):
             device["invalid_key"]
 
     def test_setitem_common_properties(self) -> None:
         """Test __setitem__ method for common properties."""
-        device = Devices.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
+        device = Device.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
 
         device["id"] = "NEW_HD"
         assert device.id == "NEW_HD"
@@ -728,14 +728,14 @@ class TestDevices:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        device = Devices.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
+        device = Device.create_heat_detector("HD1", "ROOM1", [1, 2, 3], 70.0, 50.0)
 
         with pytest.raises(KeyError, match="Cannot set 'invalid_key'"):
             device["invalid_key"] = "value"
 
     def test_repr_html_detector(self) -> None:
         """Test _repr_html_ method for detector device."""
-        device = Devices.create_heat_detector(
+        device = Device.create_heat_detector(
             id="HD_01",
             comp_id="BEDROOM",
             location=[2.0, 2.0, 2.4],
@@ -762,7 +762,7 @@ class TestDevices:
 
     def test_repr_html_target(self) -> None:
         """Test _repr_html_ method for target device."""
-        device = Devices(
+        device = Device(
             id="TEMP_01",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -788,7 +788,7 @@ class TestDevices:
 
     def test_repr_html_smoke_detector(self) -> None:
         """Test _repr_html_ method for smoke detector device."""
-        device = Devices.create_smoke_detector(
+        device = Device.create_smoke_detector(
             id="SD_01",
             comp_id="LIVING_ROOM",
             location=[3.0, 3.0, 2.4],
@@ -804,7 +804,7 @@ class TestDevices:
         assert "5.0" in html_str  # Check for setpoint value
 
 
-class TestDevicesSetItemValidation:
+class TestDeviceSetItemValidation:
     """Test validation in __setitem__ to ensure data integrity."""
 
     @pytest.mark.parametrize(
@@ -817,7 +817,7 @@ class TestDevicesSetItemValidation:
     )
     def test_setitem_invalid_location(self, invalid_location):
         """Test that __setitem__ rejects invalid location values."""
-        device = Devices(
+        device = Device(
             id="T1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 3.0],
@@ -830,7 +830,7 @@ class TestDevicesSetItemValidation:
 
     def test_setitem_target_empty_material_id(self):
         """Test that __setitem__ rejects empty material_id for target types."""
-        device = Devices(
+        device = Device(
             id="T1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 3.0],
@@ -843,7 +843,7 @@ class TestDevicesSetItemValidation:
 
     def test_setitem_target_both_normal_and_orientation(self):
         """Test that __setitem__ rejects both normal and surface_orientation set."""
-        device = Devices(
+        device = Device(
             id="T1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 3.0],
@@ -858,7 +858,7 @@ class TestDevicesSetItemValidation:
 
     def test_setitem_heat_detector_removes_setpoint(self):
         """Test that __setitem__ rejects None setpoint for heat detector."""
-        device = Devices.create_heat_detector(
+        device = Device.create_heat_detector(
             id="HD1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 3.0],
@@ -870,7 +870,7 @@ class TestDevicesSetItemValidation:
 
     def test_setitem_sprinkler_removes_spray_density(self):
         """Test that __setitem__ rejects None spray_density for sprinkler."""
-        device = Devices.create_sprinkler(
+        device = Device.create_sprinkler(
             id="SP1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 3.0],
@@ -885,7 +885,7 @@ class TestDevicesSetItemValidation:
 
     def test_setitem_valid_location_change(self):
         """Test that __setitem__ accepts valid location change."""
-        device = Devices.create_smoke_detector(
+        device = Device.create_smoke_detector(
             id="SD1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 3.0],
@@ -896,7 +896,7 @@ class TestDevicesSetItemValidation:
 
     def test_setitem_invalid_does_not_mutate_state(self):
         """Test that a failed __setitem__ rolls back to the previous value."""
-        device = Devices(
+        device = Device(
             id="T1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 3.0],

--- a/tests/units/test_fire.py
+++ b/tests/units/test_fire.py
@@ -4,18 +4,18 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pycfast.fires import Fires
+from pycfast.fire import Fire
 
 """
-Tests for the Fires class.
+Tests for the Fire class.
 """
 
 
 @pytest.fixture()
 def make_fire():
-    """Create a Fires instance with sensible defaults."""
+    """Create a Fire instance with sensible defaults."""
 
-    def _make(**kwargs: object) -> Fires:
+    def _make(**kwargs: object) -> Fire:
         defaults: dict[str, object] = {
             "id": "FIRE1",
             "comp_id": "ROOM1",
@@ -23,17 +23,17 @@ def make_fire():
             "location": [2.0, 3.0],
         }
         defaults.update(kwargs)
-        return Fires(**defaults)  # type: ignore[arg-type]
+        return Fire(**defaults)  # type: ignore[arg-type]
 
     return _make
 
 
-class TestFires:
-    """Test class for Fires."""
+class TestFire:
+    """Test class for Fire."""
 
     def test_init_basic(self):
         """Test basic initialization with required parameters."""
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -61,7 +61,7 @@ class TestFires:
             [0, 100, 0.5, 0.1, 0.01, 0.01, 0, 0, 0],
             [60, 500, 1.0, 0.5, 0.01, 0.01, 0, 0, 0],
         ]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -104,7 +104,7 @@ class TestFires:
     def test_init_invalid_location_length(self, location: list[float]):
         """Test that initialization fails with wrong location dimensions."""
         with pytest.raises(ValueError, match="Location must be a list of two floats"):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="POLYURETHANE",
@@ -141,7 +141,7 @@ class TestFires:
             [0, 100, 0.5],  # Only 3 columns instead of 9
         ]
         with pytest.raises(ValueError, match="data_table must have exactly 9 columns"):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="POLYURETHANE",
@@ -151,7 +151,7 @@ class TestFires:
 
     def test_to_input_string_basic(self):
         """Test basic input string generation."""
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -248,7 +248,7 @@ class TestFires:
             [60, 100000, 1.0, 0.5, 0.01, 0.01, 0, 0, 0],
             [300, 500000, 1.5, 1.0, 0.01, 0.01, 0, 0, 0],
         ]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -268,7 +268,7 @@ class TestFires:
 
     def test_to_input_string_with_custom_chemistry(self):
         """Test input string generation with custom chemistry parameters."""
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="METHANE",
@@ -294,7 +294,7 @@ class TestFires:
         with pytest.raises(
             ValueError, match="data_table must contain at least one row"
         ):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="POLYURETHANE",
@@ -304,7 +304,7 @@ class TestFires:
 
     def test_init_no_ignition_criterion_with_setpoint(self):
         """Test initialization with setpoint but no ignition criterion."""
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -321,7 +321,7 @@ class TestFires:
 
     def test_init_with_device_id_only(self):
         """Test initialization with device_id but no ignition criterion."""
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -342,7 +342,7 @@ class TestFires:
             [0, 100, 0.5, 0.1, 0.01, 0.01, 0, 0, 0],
             [60, 500, 1.0, 0.5, 0.01, 0.01, 0, 0, 0],
         ]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -353,7 +353,7 @@ class TestFires:
         )
 
         repr_str = repr(fire)
-        assert "Fires(" in repr_str
+        assert "Fire(" in repr_str
         assert "id='FIRE1'" in repr_str
         assert "comp_id='ROOM1'" in repr_str
         assert "fire_id='POLYURETHANE'" in repr_str
@@ -419,7 +419,7 @@ class TestFires:
     def test_getitem(self) -> None:
         """Test __getitem__ method."""
         data_table = [[0, 100, 0.5, 0.1, 0.01, 0.01, 0, 0, 0]]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -443,14 +443,14 @@ class TestFires:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        fire = Fires(id="FIRE1", comp_id="ROOM1", fire_id="WOOD", location=[1.0, 2.0])
+        fire = Fire(id="FIRE1", comp_id="ROOM1", fire_id="WOOD", location=[1.0, 2.0])
 
-        with pytest.raises(KeyError, match="Property 'invalid_key' not found in Fires"):
+        with pytest.raises(KeyError, match="Property 'invalid_key' not found in Fire"):
             fire["invalid_key"]
 
     def test_setitem(self) -> None:
         """Test __setitem__ method."""
-        fire = Fires(id="FIRE1", comp_id="ROOM1", fire_id="WOOD", location=[1.0, 2.0])
+        fire = Fire(id="FIRE1", comp_id="ROOM1", fire_id="WOOD", location=[1.0, 2.0])
 
         # Test setting various properties
         fire["id"] = "NEW_FIRE"
@@ -470,14 +470,14 @@ class TestFires:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        fire = Fires(id="FIRE1", comp_id="ROOM1", fire_id="WOOD", location=[1.0, 2.0])
+        fire = Fire(id="FIRE1", comp_id="ROOM1", fire_id="WOOD", location=[1.0, 2.0])
 
         with pytest.raises(KeyError, match="Cannot set 'invalid_key'"):
             fire["invalid_key"] = "value"
 
 
-class TestFiresDataTableFormats:
-    """Test class for Fires data_table format handling."""
+class TestFireDataTableFormats:
+    """Test class for Fire data_table format handling."""
 
     def test_data_table_list_of_lists(self):
         """Test data_table with list of lists (original format)."""
@@ -486,7 +486,7 @@ class TestFiresDataTableFormats:
             [60, 1000, 0.5, 1.0, 0.01, 0.01, 0, 0, 0],
             [300, 500, 1.0, 1.0, 0.01, 0.01, 0, 0, 0],
         ]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -504,7 +504,7 @@ class TestFiresDataTableFormats:
                 [300, 500, 1.0, 1.0, 0.01, 0.01, 0, 0, 0],
             ]
         )
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -529,7 +529,7 @@ class TestFiresDataTableFormats:
                 "TRACE_YIELD": [0, 0, 0],
             }
         )
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -547,7 +547,7 @@ class TestFiresDataTableFormats:
             [300, 500, 1.0, 1.0, 0.01, 0.01, 0, 0, 0],
         ]
         df = pd.DataFrame(data)  # Will have columns 0, 1, 2, ..., 8
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -560,7 +560,7 @@ class TestFiresDataTableFormats:
         """Test that 1D NumPy array raises error."""
         data_array = np.array([0, 1000, 0.5, 1.0, 0.01, 0.01, 0, 0, 0])  # 1D array
         with pytest.raises(ValueError, match="NumPy array must be 2-dimensional"):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="WOOD",
@@ -577,7 +577,7 @@ class TestFiresDataTableFormats:
             ]
         )
         with pytest.raises(ValueError, match="NumPy array must have exactly 9 columns"):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="WOOD",
@@ -595,7 +595,7 @@ class TestFiresDataTableFormats:
             }
         )
         with pytest.raises(ValueError, match="DataFrame must have 9 columns"):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="WOOD",
@@ -609,7 +609,7 @@ class TestFiresDataTableFormats:
             TypeError,
             match="data_table must be a list of lists, NumPy array, pandas DataFrame, or None",
         ):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="WOOD",
@@ -625,7 +625,7 @@ class TestFiresDataTableFormats:
         with pytest.raises(
             ValueError, match="All values in data_table must be numeric"
         ):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="WOOD",
@@ -638,7 +638,7 @@ class TestFiresDataTableFormats:
         with pytest.raises(
             ValueError, match="data_table must contain at least one row"
         ):
-            Fires(
+            Fire(
                 id="FIRE1",
                 comp_id="ROOM1",
                 fire_id="WOOD",
@@ -653,7 +653,7 @@ class TestFiresDataTableFormats:
             [60, 1000, 0.5, 1.0, 0.01, 0.01, 0, 0, 0],
             [300, 500, 1.0, 1.0, 0.01, 0.01, 0, 0, 0],
         ]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -667,7 +667,7 @@ class TestFiresDataTableFormats:
         assert isinstance(df, pd.DataFrame)
 
         # Check column names
-        assert list(df.columns) == Fires.LABELS
+        assert list(df.columns) == Fire.LABELS
 
         # Check data content
         assert df.values.tolist() == data_table
@@ -694,7 +694,7 @@ class TestFiresDataTableFormats:
         )
 
         # Create Fire from DataFrame
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -715,7 +715,7 @@ class TestFiresDataTableFormats:
             [0, 0, 0.5, 0.1, 0.01, 0.01, 0, 0, 0],  # mix of int and float
             [60.0, 1000, 0.5, 1, 0.01, 0.01, 0, 0, 0],  # mix of float and int
         ]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="WOOD",
@@ -734,7 +734,7 @@ class TestFiresDataTableFormats:
             [0, 100, 0.5, 0.1, 0.01, 0.01, 0, 0, 0],
             [60, 500, 1.0, 0.5, 0.01, 0.01, 0, 0, 0],
         ]
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
@@ -763,7 +763,7 @@ class TestFiresDataTableFormats:
         assert "2" in html_str  # data rows count - more flexible check
 
 
-class TestFiresSetItemValidation:
+class TestFireSetItemValidation:
     """Test validation in __setitem__ to ensure data integrity."""
 
     def test_setitem_invalid_location_too_few(self, make_fire):

--- a/tests/units/test_material.py
+++ b/tests/units/test_material.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import pytest
 
-from pycfast.material_properties import MaterialProperties
+from pycfast.material import Material
 
 """
-Tests for the MaterialProperties class.
+Tests for the Material class.
 """
 
 
-class TestMaterialProperties:
-    """Test class for MaterialProperties."""
+class TestMaterial:
+    """Test class for Material."""
 
     def test_init_default(self):
         """Test default initialization."""
-        mat = MaterialProperties(id="NM1", material="New Material 1")
+        mat = Material(id="NM1", material="New Material 1")
 
         assert mat.id == "NM1"
         assert mat.material == "New Material 1"
@@ -26,7 +26,7 @@ class TestMaterialProperties:
 
     def test_init_with_all_parameters(self):
         """Test initialization with all parameters."""
-        mat = MaterialProperties(
+        mat = Material(
             id="GYPSUM",
             material="Gypsum Wallboard",
             conductivity=0.17,
@@ -46,7 +46,7 @@ class TestMaterialProperties:
     def test_init_different_materials(self):
         """Test initialization with different material types."""
         # Steel
-        steel = MaterialProperties(
+        steel = Material(
             id="STEEL",
             material="Structural Steel",
             conductivity=45.0,
@@ -60,7 +60,7 @@ class TestMaterialProperties:
         assert steel.density == 7850
 
         # Wood
-        wood = MaterialProperties(
+        wood = Material(
             id="WOOD",
             material="Pine Wood",
             conductivity=0.14,
@@ -75,27 +75,23 @@ class TestMaterialProperties:
     def test_init_invalid_id_type(self):
         """Test that initialization fails with non-string ID."""
         with pytest.raises(TypeError, match="id must be a string"):
-            MaterialProperties(id=123, material="Test Material")  # type: ignore
+            Material(id=123, material="Test Material")  # type: ignore
 
     def test_init_invalid_id_length(self):
         """Test that initialization fails with ID too long."""
         with pytest.raises(
             TypeError, match="id must be a string with no more than 16 characters"
         ):
-            MaterialProperties(
-                id="THIS_ID_IS_TOO_LONG_FOR_CFAST", material="Test Material"
-            )
+            Material(id="THIS_ID_IS_TOO_LONG_FOR_CFAST", material="Test Material")
 
     def test_init_boundary_id_length(self):
         """Test initialization with ID exactly at 16 character limit."""
-        mat = MaterialProperties(
-            id="EXACTLY_16_CHARS", material="Test Material"
-        )  # 16 characters
+        mat = Material(id="EXACTLY_16_CHARS", material="Test Material")  # 16 characters
         assert mat.id == "EXACTLY_16_CHARS"
 
     def test_to_input_string_basic(self):
         """Test basic input string generation."""
-        mat = MaterialProperties(
+        mat = Material(
             id="GYPSUM",
             material="Gypsum Board",
             conductivity=0.17,
@@ -118,7 +114,7 @@ class TestMaterialProperties:
 
     def test_to_input_string_with_spaces_in_material_name(self):
         """Test input string generation with spaces in material name."""
-        mat = MaterialProperties(
+        mat = Material(
             id="CONCRETE",
             material="High Density Concrete",
             conductivity=1.75,
@@ -132,7 +128,7 @@ class TestMaterialProperties:
 
     def test_to_input_string_integer_values(self):
         """Test input string generation with integer values."""
-        mat = MaterialProperties(
+        mat = Material(
             id="MAT1",
             material="Test Material",
             conductivity=1,  # Integer
@@ -150,7 +146,7 @@ class TestMaterialProperties:
 
     def test_to_input_string_float_values(self):
         """Test input string generation with float values."""
-        mat = MaterialProperties(
+        mat = Material(
             id="MAT2",
             material="Test Material",
             conductivity=0.123456,
@@ -168,7 +164,7 @@ class TestMaterialProperties:
 
     def test_to_input_string_default_values(self):
         """Test input string generation with default values omits None fields."""
-        mat = MaterialProperties(id="NM1", material="New Material 1")
+        mat = Material(id="NM1", material="New Material 1")
         result = mat.to_input_string()
         assert result.startswith("&MATL")
         assert result.endswith("/\n")
@@ -184,7 +180,7 @@ class TestMaterialProperties:
 
     def test_to_input_string_special_characters_in_name(self):
         """Test input string generation with special characters in material name."""
-        mat = MaterialProperties(
+        mat = Material(
             id="SPECIAL",
             material="Material-123 (Type A)",
             conductivity=0.5,
@@ -213,12 +209,12 @@ class TestMaterialProperties:
         """Test that zero or negative physical properties raise ValueError."""
         kwargs = {"id": "ZERO", "material": "Test Material", prop: value}
         with pytest.raises(ValueError, match=f"{prop} must be positive"):
-            MaterialProperties(**kwargs)
+            Material(**kwargs)
 
     def test_emissivity_warning(self):
         """Test that emissivity values outside 0-1 raise a warning."""
         with pytest.warns(UserWarning, match="This may cause inaccurate results"):
-            MaterialProperties(
+            Material(
                 id="TestMat",
                 material="Test Material",
                 emissivity=1.5,
@@ -226,7 +222,7 @@ class TestMaterialProperties:
 
     def test_to_input_string_ends_correctly(self):
         """Test that input string ends with proper format."""
-        mat = MaterialProperties(id="NM1", material="New Material 1")
+        mat = Material(id="NM1", material="New Material 1")
         result = mat.to_input_string()
         assert result.startswith("&MATL")
         assert result.endswith("/\n")
@@ -241,12 +237,12 @@ class TestMaterialProperties:
     )
     def test_id_validation_edge_cases(self, mat_id: str):
         """Test ID validation edge cases."""
-        mat = MaterialProperties(id=mat_id, material="Test Material")
+        mat = Material(id=mat_id, material="Test Material")
         assert mat.id == mat_id
 
     def test_none_values_handling(self):
         """Test handling of None values in parameters."""
-        mat = MaterialProperties(
+        mat = Material(
             id="TEST",
             material="Test Material",
             conductivity=None,
@@ -267,7 +263,7 @@ class TestMaterialProperties:
     # Tests for dunder methods
     def test_repr(self) -> None:
         """Test __repr__ method."""
-        mat = MaterialProperties(
+        mat = Material(
             id="GYPSUM",
             material="Gypsum Wallboard",
             conductivity=0.17,
@@ -278,7 +274,7 @@ class TestMaterialProperties:
         )
 
         repr_str = repr(mat)
-        assert "MaterialProperties(" in repr_str
+        assert "Material(" in repr_str
         assert "id='GYPSUM'" in repr_str
         assert "material='Gypsum Wallboard'" in repr_str
         assert "conductivity=0.17" in repr_str
@@ -286,7 +282,7 @@ class TestMaterialProperties:
 
     def test_str(self) -> None:
         """Test __str__ method."""
-        mat = MaterialProperties(
+        mat = Material(
             id="CONCRETE",
             material="Normal Weight Concrete",
             conductivity=1.2,
@@ -307,7 +303,7 @@ class TestMaterialProperties:
 
     def test_str_with_none_values(self) -> None:
         """Test __str__ method with None values."""
-        mat = MaterialProperties(
+        mat = Material(
             id="INCOMPLETE",
             material="Incomplete Material",
             conductivity=None,
@@ -322,7 +318,7 @@ class TestMaterialProperties:
 
     def test_getitem(self) -> None:
         """Test __getitem__ method."""
-        mat = MaterialProperties(
+        mat = Material(
             id="WOOD",
             material="Oak Wood",
             conductivity=0.16,
@@ -342,16 +338,16 @@ class TestMaterialProperties:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        mat = MaterialProperties(id="STEEL", material="Steel Material")
+        mat = Material(id="STEEL", material="Steel Material")
 
         with pytest.raises(
-            KeyError, match="Property 'invalid_key' not found in MaterialProperties"
+            KeyError, match="Property 'invalid_key' not found in Material"
         ):
             mat["invalid_key"]
 
     def test_setitem(self) -> None:
         """Test __setitem__ method."""
-        mat = MaterialProperties(id="TEST_MAT", material="Test Material")
+        mat = Material(id="TEST_MAT", material="Test Material")
 
         # Test setting various properties
         mat["id"] = "NEW_MATERIAL"
@@ -377,7 +373,7 @@ class TestMaterialProperties:
 
     def test_setitem_none_values(self) -> None:
         """Test __setitem__ method with None values."""
-        mat = MaterialProperties(id="TEST_MAT", material="Test Material")
+        mat = Material(id="TEST_MAT", material="Test Material")
 
         mat["material"] = None
         assert mat.material is None
@@ -390,14 +386,14 @@ class TestMaterialProperties:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        mat = MaterialProperties(id="TEST_MAT", material="Test Material")
+        mat = Material(id="TEST_MAT", material="Test Material")
 
         with pytest.raises(KeyError, match="Cannot set 'invalid_key'"):
             mat["invalid_key"] = "value"
 
     def test_repr_html(self) -> None:
         """Test _repr_html_ method."""
-        mat = MaterialProperties(
+        mat = Material(
             id="GYPSUM",
             material="Gypsum Wallboard",
             conductivity=0.17,
@@ -435,7 +431,7 @@ class TestMaterialProperties:
 
     def test_repr_html_with_none_values(self) -> None:
         """Test _repr_html_ method handles None values properly."""
-        mat = MaterialProperties(id="TEST", material="Test Material")
+        mat = Material(id="TEST", material="Test Material")
         mat.conductivity = None
         mat.density = None
 
@@ -447,7 +443,7 @@ class TestMaterialProperties:
         assert "None W/m·K" in html_str  # getattr shows None for None values
 
 
-class TestMaterialPropertiesSetItemValidation:
+class TestMaterialSetItemValidation:
     """Test validation in __setitem__ to ensure data integrity."""
 
     @pytest.mark.parametrize(
@@ -459,31 +455,25 @@ class TestMaterialPropertiesSetItemValidation:
     )
     def test_setitem_invalid_id(self, invalid_id):
         """Test that __setitem__ rejects invalid id values."""
-        mat = MaterialProperties(
-            id="VALID", material="Concrete", conductivity=1.6, density=2400
-        )
+        mat = Material(id="VALID", material="Concrete", conductivity=1.6, density=2400)
         with pytest.raises(TypeError, match="id must be a string"):
             mat["id"] = invalid_id
 
     def test_setitem_valid_id(self):
         """Test that __setitem__ accepts valid id change."""
-        mat = MaterialProperties(
-            id="VALID", material="Concrete", conductivity=1.6, density=2400
-        )
+        mat = Material(id="VALID", material="Concrete", conductivity=1.6, density=2400)
         mat["id"] = "NEW_ID"
         assert mat.id == "NEW_ID"
 
     def test_setitem_valid_conductivity(self):
         """Test that __setitem__ accepts valid conductivity change."""
-        mat = MaterialProperties(
-            id="VALID", material="Concrete", conductivity=1.6, density=2400
-        )
+        mat = Material(id="VALID", material="Concrete", conductivity=1.6, density=2400)
         mat["conductivity"] = 2.0
         assert mat.conductivity == 2.0
 
     def test_setitem_invalid_does_not_mutate_state(self):
         """Test that a failed __setitem__ rolls back to the previous value."""
-        mat = MaterialProperties(
+        mat = Material(
             id="VALID_ID", material="Concrete", conductivity=1.6, density=2400
         )
 

--- a/tests/units/test_mechanical_vent.py
+++ b/tests/units/test_mechanical_vent.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import pytest
 
-from pycfast.mechanical_vents import MechanicalVents
+from pycfast.mechanical_vent import MechanicalVent
 
 """
-Tests for the MechanicalVents class.
+Tests for the MechanicalVent class.
 """
 
 
 @pytest.fixture()
 def make_mechanical_vent():
-    """Create a MechanicalVents instance with sensible defaults."""
+    """Create a MechanicalVent instance with sensible defaults."""
 
-    def _make(**kwargs: object) -> MechanicalVents:
+    def _make(**kwargs: object) -> MechanicalVent:
         defaults: dict[str, object] = {
             "id": "FAN1",
             "comps_ids": ["OUTSIDE", "ROOM1"],
@@ -27,17 +27,17 @@ def make_mechanical_vent():
             "filter_efficiency": 0.0,
         }
         defaults.update(kwargs)
-        return MechanicalVents(**defaults)  # type: ignore[arg-type]
+        return MechanicalVent(**defaults)  # type: ignore[arg-type]
 
     return _make
 
 
-class TestMechanicalVents:
-    """Test class for MechanicalVents."""
+class TestMechanicalVent:
+    """Test class for MechanicalVent."""
 
     def test_init_basic(self):
         """Test basic initialization with minimal parameters."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="VENT_1",
             comps_ids=["ROOM1", "ROOM2"],
             area=[0.5, 0.5],
@@ -58,7 +58,7 @@ class TestMechanicalVents:
 
     def test_init_with_all_parameters(self):
         """Test initialization with all parameters."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="SUPPLY_1",
             comps_ids=["OUTSIDE", "ROOM1"],
             area=[0.1, 0.1],
@@ -105,7 +105,7 @@ class TestMechanicalVents:
     def test_init_invalid_comps_ids_length(self, comps_ids: list[str]):
         """Test that initialization fails with wrong number of compartments."""
         with pytest.raises(ValueError, match="exactly 2 compartment IDs"):
-            MechanicalVents(id="FAN1", comps_ids=comps_ids)
+            MechanicalVent(id="FAN1", comps_ids=comps_ids)
 
     @pytest.mark.parametrize(
         ("field", "bad_value", "match"),
@@ -137,7 +137,7 @@ class TestMechanicalVents:
     def test_init_invalid_list_length(self, field: str, bad_value: list, match: str):
         """Test that initialization fails with wrong list length."""
         with pytest.raises(ValueError, match=match):
-            MechanicalVents(
+            MechanicalVent(
                 id="FAN1",
                 comps_ids=["OUTSIDE", "ROOM1"],
                 **{field: bad_value},
@@ -153,7 +153,7 @@ class TestMechanicalVents:
     def test_init_negative_cutoffs(self, cutoffs: list[float]):
         """Test that initialization fails with negative cutoff values."""
         with pytest.raises(ValueError, match="cutoffs must be non-negative"):
-            MechanicalVents(
+            MechanicalVent(
                 id="FAN1",
                 comps_ids=["OUTSIDE", "ROOM1"],
                 cutoffs=cutoffs,
@@ -162,7 +162,7 @@ class TestMechanicalVents:
     def test_init_invalid_cutoffs_order(self):
         """Test that initialization fails when second cutoff is less than first."""
         with pytest.raises(ValueError, match="Zero flow pressure must be greater"):
-            MechanicalVents(
+            MechanicalVent(
                 id="FAN1",
                 comps_ids=["OUTSIDE", "ROOM1"],
                 cutoffs=[150.0, 100.0],  # Second cutoff less than first
@@ -197,7 +197,7 @@ class TestMechanicalVents:
 
     def test_to_input_string_basic(self):
         """Test basic input string generation."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="FAN1",
             comps_ids=["OUTSIDE", "ROOM1"],
             area=[0.1, 0.1],
@@ -255,7 +255,7 @@ class TestMechanicalVents:
 
     def test_to_input_string_exhaust_fan(self):
         """Test input string generation for exhaust fan (negative flow)."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="EXHAUST1",
             comps_ids=["ROOM1", "OUTSIDE"],
             area=[0.05, 0.05],
@@ -274,7 +274,7 @@ class TestMechanicalVents:
 
     def test_to_input_string_with_filtration(self):
         """Test input string generation with filtration parameters."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="FILTERED_SUPPLY",
             comps_ids=["OUTSIDE", "ROOM1"],
             area=[0.2, 0.2],
@@ -306,7 +306,7 @@ class TestMechanicalVents:
 
     def test_to_input_string_multiple_orientations(self):
         """Test input string generation with different orientations."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="MIXED_VENT",
             comps_ids=["ROOM1", "ROOM2"],
             area=[0.1, 0.2],
@@ -326,7 +326,7 @@ class TestMechanicalVents:
 
     def test_to_input_string_none_filter_params(self):
         """Test input string generation with None filter parameters."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="FAN1",
             comps_ids=["OUTSIDE", "ROOM1"],
             area=[0.1, 0.1],
@@ -345,7 +345,7 @@ class TestMechanicalVents:
 
     def test_default_values_initialization(self):
         """Test that default values are properly set during initialization."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="FAN1",
             comps_ids=["OUTSIDE", "ROOM1"],
             offsets=[0.0, 1.0],  # Required parameter
@@ -360,7 +360,7 @@ class TestMechanicalVents:
 
     def test_repr(self) -> None:
         """Test __repr__ method."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="SUPPLY_FAN",
             comps_ids=["OUTSIDE", "LOBBY"],
             area=[0.2, 0.2],
@@ -372,7 +372,7 @@ class TestMechanicalVents:
         )
 
         repr_str = repr(vent)
-        assert "MechanicalVents(" in repr_str
+        assert "MechanicalVent(" in repr_str
         assert "id='SUPPLY_FAN'" in repr_str
         assert "comps_ids=['OUTSIDE', 'LOBBY']" in repr_str
         assert "flow=1.2" in repr_str
@@ -381,7 +381,7 @@ class TestMechanicalVents:
 
     def test_str(self) -> None:
         """Test __str__ method."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="EXHAUST_01",
             comps_ids=["KITCHEN", "OUTSIDE"],
             area=[0.15, 0.15],
@@ -399,7 +399,7 @@ class TestMechanicalVents:
 
     def test_str_with_supply_flow(self) -> None:
         """Test __str__ method with positive supply flow."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="SUPPLY_02",
             comps_ids=["OUTSIDE", "BEDROOM"],
             area=[0.1, 0.1],
@@ -415,7 +415,7 @@ class TestMechanicalVents:
 
     def test_getitem(self) -> None:
         """Test __getitem__ method."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="TEST_VENT",
             comps_ids=["ROOM_A", "ROOM_B"],
             area=[0.25, 0.25],
@@ -449,7 +449,7 @@ class TestMechanicalVents:
 
     def test_getitem_with_none_values(self) -> None:
         """Test __getitem__ method with None values."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="MINIMAL_VENT", comps_ids=["ROOM1", "ROOM2"], offsets=[0.0, 0.0]
         )
 
@@ -462,18 +462,18 @@ class TestMechanicalVents:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="VENT1", comps_ids=["ROOM1", "ROOM2"], offsets=[0.0, 0.0]
         )
 
         with pytest.raises(
-            KeyError, match="Property 'invalid_property' not found in MechanicalVents"
+            KeyError, match="Property 'invalid_property' not found in MechanicalVent"
         ):
             vent["invalid_property"]
 
     def test_setitem(self) -> None:
         """Test __setitem__ method."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="MODIFIABLE_VENT",
             comps_ids=["HALL", "OFFICE"],
             area=[0.12, 0.12],
@@ -501,7 +501,7 @@ class TestMechanicalVents:
 
     def test_setitem_compartment_lists(self) -> None:
         """Test __setitem__ method with compartment lists."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="LIST_VENT", comps_ids=["ROOM1", "ROOM2"], offsets=[0.0, 0.0]
         )
 
@@ -512,19 +512,19 @@ class TestMechanicalVents:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="VENT1", comps_ids=["ROOM1", "ROOM2"], offsets=[0.0, 0.0]
         )
 
         with pytest.raises(
             KeyError,
-            match="Cannot set 'nonexistent_attr'. Property does not exist in MechanicalVents",
+            match="Cannot set 'nonexistent_attr'. Property does not exist in MechanicalVent",
         ):
             vent["nonexistent_attr"] = "some_value"
 
     def test_repr_html(self) -> None:
         """Test _repr_html_ method."""
-        vent = MechanicalVents(
+        vent = MechanicalVent(
             id="SUPPLY_FAN",
             comps_ids=["OUTSIDE", "LOBBY"],
             area=[0.2, 0.2],
@@ -552,7 +552,7 @@ class TestMechanicalVents:
         assert "0.2" in html_str  # area
 
 
-class TestMechanicalVentsSetItemValidation:
+class TestMechanicalVentSetItemValidation:
     """Test validation in __setitem__ to ensure data integrity."""
 
     @pytest.mark.parametrize(

--- a/tests/units/test_model.py
+++ b/tests/units/test_model.py
@@ -9,16 +9,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pycfast.ceiling_floor_vents import CeilingFloorVents
-from pycfast.compartments import Compartments
-from pycfast.devices import Devices
-from pycfast.fires import Fires
-from pycfast.material_properties import MaterialProperties
-from pycfast.mechanical_vents import MechanicalVents
+from pycfast.ceiling_floor_vent import CeilingFloorVent
+from pycfast.compartment import Compartment
+from pycfast.device import Device
+from pycfast.fire import Fire
+from pycfast.material import Material
+from pycfast.mechanical_vent import MechanicalVent
 from pycfast.model import CFASTModel, _resolve_cfast_exe
 from pycfast.simulation_environment import SimulationEnvironment
-from pycfast.surface_connections import SurfaceConnections
-from pycfast.wall_vents import WallVents
+from pycfast.surface_connection import SurfaceConnection
+from pycfast.wall_vent import WallVent
 
 """
 Tests for the CFASTModel class.
@@ -31,7 +31,7 @@ class TestCFASTModel:
     def create_minimal_model(self) -> CFASTModel:
         """Create a minimal valid CFASTModel for testing."""
         simulation_env = SimulationEnvironment(title="Test Simulation")
-        compartment = Compartments(id="ROOM1", width=3.0, depth=4.0, height=2.4)
+        compartment = Compartment(id="ROOM1", width=3.0, depth=4.0, height=2.4)
 
         return CFASTModel(
             simulation_environment=simulation_env,
@@ -43,12 +43,12 @@ class TestCFASTModel:
         """Create a fully configured CFASTModel for testing."""
         simulation_env = SimulationEnvironment(title="Full Test Simulation")
 
-        compartment1 = Compartments(id="ROOM1", width=3.0, depth=4.0, height=2.4)
-        compartment2 = Compartments(id="ROOM2", width=4.0, depth=4.0, height=2.4)
+        compartment1 = Compartment(id="ROOM1", width=3.0, depth=4.0, height=2.4)
+        compartment2 = Compartment(id="ROOM2", width=4.0, depth=4.0, height=2.4)
 
-        material = MaterialProperties(id="GYPSUM", material="Gypsum Board")
+        material = Material(id="GYPSUM", material="Gypsum Board")
 
-        wall_vent = WallVents(
+        wall_vent = WallVent(
             id="DOOR1",
             comps_ids=["ROOM1", "ROOM2"],
             bottom=0.0,
@@ -57,26 +57,26 @@ class TestCFASTModel:
             face="RIGHT",
         )
 
-        ceiling_vent = CeilingFloorVents(
+        ceiling_vent = CeilingFloorVent(
             id="CEILING1",
             comps_ids=["ROOM1", "ROOM2"],
             area=1.0,
         )
 
-        mechanical_vent = MechanicalVents(
+        mechanical_vent = MechanicalVent(
             id="FAN1",
             comps_ids=["OUTSIDE", "ROOM1"],
             offsets=[0.0, 1.0],
         )
 
-        fire = Fires(
+        fire = Fire(
             id="FIRE1",
             comp_id="ROOM1",
             fire_id="POLYURETHANE",
             location=[2.0, 2.0],
         )
 
-        device = Devices(
+        device = Device(
             id="TEMP1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -86,7 +86,7 @@ class TestCFASTModel:
             rti=50.0,
         )
 
-        surface_conn = SurfaceConnections.wall_connection(
+        surface_conn = SurfaceConnection.wall_connection(
             comp_id="ROOM1",
             comp_ids="ROOM2",
             fraction=0.5,
@@ -147,7 +147,7 @@ class TestCFASTModel:
     def test_init_with_custom_cfast_exe(self):
         """Test initialization with custom CFAST executable path."""
         simulation_env = SimulationEnvironment(title="Test")
-        compartment = Compartments(id="ROOM1")
+        compartment = Compartment(id="ROOM1")
 
         model = CFASTModel(
             simulation_environment=simulation_env,
@@ -160,7 +160,7 @@ class TestCFASTModel:
     def test_init_cfast_exe_none_by_default(self):
         """Test that cfast_exe is stored as None when not provided."""
         simulation_env = SimulationEnvironment(title="Test")
-        compartment = Compartments(id="ROOM1")
+        compartment = Compartment(id="ROOM1")
 
         model = CFASTModel(
             simulation_environment=simulation_env,
@@ -488,7 +488,7 @@ class TestCFASTModel:
     def test_empty_lists_initialization(self):
         """Test that None values are converted to empty lists."""
         simulation_env = SimulationEnvironment(title="Test")
-        compartment = Compartments(id="ROOM1")
+        compartment = Compartment(id="ROOM1")
 
         model = CFASTModel(
             simulation_environment=simulation_env,
@@ -606,10 +606,10 @@ class TestCFASTModel:
 
         str_repr = str(model)
         assert "full_test.in" in str_repr
-        assert "Compartments (2):" in str_repr
-        assert "Fires (1):" in str_repr
+        assert "Compartment (2):" in str_repr
+        assert "Fire (1):" in str_repr
         assert "Wall Vents (1):" in str_repr
-        assert "Devices (1):" in str_repr
+        assert "Device (1):" in str_repr
         assert "Material Properties (1):" in str_repr
 
     # Note: __len__, __bool__, __eq__, __hash__, __contains__ methods not implemented in current version
@@ -668,12 +668,12 @@ class TestCFASTModel:
         model = self.create_minimal_model()
 
         # Test setting compartments
-        new_compartment = Compartments(id="NEW_ROOM", width=5, depth=5, height=3)
+        new_compartment = Compartment(id="NEW_ROOM", width=5, depth=5, height=3)
         model["compartments"] = [new_compartment]
         assert model.compartments == [new_compartment]
 
         # Test setting fires
-        new_fire = Fires(
+        new_fire = Fire(
             id="NEW_FIRE", comp_id="NEW_ROOM", fire_id="WOOD", location=[1, 1]
         )
         model["fires"] = [new_fire]
@@ -700,7 +700,7 @@ class TestCFASTModel:
         # Check that key information is in the output
         assert "Model: test.in" in result
         assert "Test Simulation" in result
-        assert "Compartments (1):" in result
+        assert "Compartment (1):" in result
         assert "28.80 m³" in result  # Volume calculation: 3.0 * 4.0 * 2.4
 
     def test_summary_with_full_model(self) -> None:
@@ -710,10 +710,10 @@ class TestCFASTModel:
         result = model.summary()
 
         # Check that all component types are shown
-        assert "Compartments (2):" in result
-        assert "Fires (1):" in result
+        assert "Compartment (2):" in result
+        assert "Fire (1):" in result
         assert "Wall Vents (1):" in result
-        assert "Devices (1):" in result
+        assert "Device (1):" in result
 
     # Tests for update methods
     def test_update_fire_params(self) -> None:
@@ -1058,7 +1058,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_fire_count = len(model.fires)
 
-        new_fire = Fires(
+        new_fire = Fire(
             id="FIRE2", comp_id="ROOM1", fire_id="FIRE2", location=[3.0, 3.0]
         )
         updated_model = model.add_fire(new_fire)
@@ -1081,7 +1081,7 @@ class TestCFASTModel:
         new_model = copy.deepcopy(model)
         new_model.fires = []
 
-        new_fire = Fires(
+        new_fire = Fire(
             id="FIRE1", comp_id="ROOM1", fire_id="FIRE1", location=[2.0, 2.0]
         )
         updated_model = new_model.add_fire(new_fire)
@@ -1094,7 +1094,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_comp_count = len(model.compartments)
 
-        new_room = Compartments(id="ROOM3", width=5.0, depth=4.0, height=3.0)
+        new_room = Compartment(id="ROOM3", width=5.0, depth=4.0, height=3.0)
         updated_model = model.add_compartment(new_room)
 
         # Check that original model is unchanged
@@ -1110,9 +1110,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_mat_count = len(model.material_properties)
 
-        steel = MaterialProperties(
-            id="STEEL", material="Steel", conductivity=45.0, density=7850
-        )
+        steel = Material(id="STEEL", material="Steel", conductivity=45.0, density=7850)
         updated_model = model.add_material(steel)
 
         # Check that original model is unchanged
@@ -1128,9 +1126,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_vent_count = len(model.wall_vents)
 
-        door = WallVents(
-            id="DOOR2", comps_ids=["ROOM1", "ROOM2"], width=1.0, height=2.0
-        )
+        door = WallVent(id="DOOR2", comps_ids=["ROOM1", "ROOM2"], width=1.0, height=2.0)
         updated_model = model.add_wall_vent(door)
 
         # Check that original model is unchanged
@@ -1146,7 +1142,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_vent_count = len(model.ceiling_floor_vents)
 
-        hatch = CeilingFloorVents(id="HATCH2", comps_ids=["ROOM1", "ROOM2"], area=0.5)
+        hatch = CeilingFloorVent(id="HATCH2", comps_ids=["ROOM1", "ROOM2"], area=0.5)
         updated_model = model.add_ceiling_floor_vent(hatch)
 
         # Check that original model is unchanged
@@ -1162,7 +1158,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_vent_count = len(model.mechanical_vents)
 
-        hvac = MechanicalVents(id="HVAC2", comps_ids=["ROOM1", "OUTSIDE"], flow=0.5)
+        hvac = MechanicalVent(id="HVAC2", comps_ids=["ROOM1", "OUTSIDE"], flow=0.5)
         updated_model = model.add_mechanical_vent(hvac)
 
         # Check that original model is unchanged
@@ -1178,7 +1174,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_device_count = len(model.devices)
 
-        sensor = Devices.create_heat_detector(
+        sensor = Device.create_heat_detector(
             id="SENSOR2",
             comp_id="ROOM1",
             location=[2.0, 2.0, 2.4],
@@ -1200,7 +1196,7 @@ class TestCFASTModel:
         model = self.create_full_model()
         original_conn_count = len(model.surface_connections)
 
-        wall_conn = SurfaceConnections.wall_connection(
+        wall_conn = SurfaceConnection.wall_connection(
             comp_id="ROOM1", comp_ids="ROOM2", fraction=0.5
         )
         updated_model = model.add_surface_connection(wall_conn)
@@ -1210,7 +1206,7 @@ class TestCFASTModel:
 
         # Check that new model has additional surface connection
         assert len(updated_model.surface_connections) == original_conn_count + 1
-        # Note: comp_ids is stored as a string in SurfaceConnections, not a list
+        # Note: comp_ids is stored as a string in SurfaceConnection, not a list
         assert updated_model.surface_connections[-1].comp_id == "ROOM1"
         assert updated_model.surface_connections[-1].comp_ids == "ROOM2"
         assert updated_model.surface_connections[-1].fraction == 0.5
@@ -1222,13 +1218,11 @@ class TestCFASTModel:
         # Chain multiple add operations
         updated_model = (
             model.add_fire(
-                Fires(id="FIRE2", comp_id="ROOM1", fire_id="FIRE2", location=[3.0, 3.0])
+                Fire(id="FIRE2", comp_id="ROOM1", fire_id="FIRE2", location=[3.0, 3.0])
             )
-            .add_compartment(Compartments(id="ROOM3", width=5.0, depth=4.0, height=3.0))
+            .add_compartment(Compartment(id="ROOM3", width=5.0, depth=4.0, height=3.0))
             .add_material(
-                MaterialProperties(
-                    id="STEEL", material="Steel", conductivity=45.0, density=7850
-                )
+                Material(id="STEEL", material="Steel", conductivity=45.0, density=7850)
             )
         )
 
@@ -1250,7 +1244,7 @@ class TestCFASTModel:
         """Test add methods when component lists are None."""
         # Create minimal model with only required components
         simulation_env = SimulationEnvironment(title="Test", time_simulation=1000)
-        room = Compartments(id="ROOM1", width=3.0, depth=3.0, height=2.5)
+        room = Compartment(id="ROOM1", width=3.0, depth=3.0, height=2.5)
 
         model = CFASTModel(
             simulation_environment=simulation_env,
@@ -1262,15 +1256,15 @@ class TestCFASTModel:
         )
 
         # Test adding to None lists
-        fire = Fires(id="FIRE1", comp_id="ROOM1", fire_id="FIRE1", location=[1.0, 1.0])
-        device = Devices.create_heat_detector(
+        fire = Fire(id="FIRE1", comp_id="ROOM1", fire_id="FIRE1", location=[1.0, 1.0])
+        device = Device.create_heat_detector(
             id="SENSOR1",
             comp_id="ROOM1",
             location=[2.0, 2.0, 2.4],
             setpoint=68.0,
             rti=50.0,
         )
-        material = MaterialProperties(
+        material = Material(
             id="CONCRETE", material="Concrete", conductivity=1.4, density=2300
         )
 
@@ -1545,8 +1539,8 @@ class TestCFASTModel:
         assert model.simulation_environment.title in html_str
 
         # Check for component counts - verify actual format
-        assert "Compartments" in html_str  # Check section exists
-        assert "Fires" in html_str
+        assert "Compartment" in html_str  # Check section exists
+        assert "Fire" in html_str
         assert "Materials" in html_str
 
 
@@ -1559,11 +1553,11 @@ class TestCFASTModelValidateDependencies:
 
     @pytest.fixture()
     def room1(self):
-        return Compartments(id="ROOM1", width=3.0, depth=4.0, height=2.4)
+        return Compartment(id="ROOM1", width=3.0, depth=4.0, height=2.4)
 
     @pytest.fixture()
     def room2(self):
-        return Compartments(id="ROOM2", width=3.0, depth=4.0, height=2.4)
+        return Compartment(id="ROOM2", width=3.0, depth=4.0, height=2.4)
 
     def _make(self, sim_env, compartments, **kwargs):
         return CFASTModel(
@@ -1574,33 +1568,33 @@ class TestCFASTModelValidateDependencies:
 
     def test_too_many_compartments(self, sim_env):
         """Test that more than 100 compartments raises ValueError."""
-        compartments = [Compartments(id=f"ROOM{i}") for i in range(101)]
+        compartments = [Compartment(id=f"ROOM{i}") for i in range(101)]
         with pytest.raises(ValueError, match="maximum of 100 compartments"):
             self._make(sim_env, compartments)
 
     def test_duplicate_compartment_ids(self, sim_env):
         """Test that duplicate compartment IDs raises ValueError."""
         with pytest.raises(ValueError, match="Duplicate id 'ROOM1'"):
-            self._make(sim_env, [Compartments(id="ROOM1"), Compartments(id="ROOM1")])
+            self._make(sim_env, [Compartment(id="ROOM1"), Compartment(id="ROOM1")])
 
     def test_duplicate_fire_ids(self, sim_env, room1):
         """Test that duplicate fire IDs raises ValueError."""
-        fire = Fires(id="FIRE1", comp_id="ROOM1", fire_id="PU", location=[1.0, 1.0])
-        fire_dup = Fires(id="FIRE1", comp_id="ROOM1", fire_id="PU", location=[2.0, 2.0])
+        fire = Fire(id="FIRE1", comp_id="ROOM1", fire_id="PU", location=[1.0, 1.0])
+        fire_dup = Fire(id="FIRE1", comp_id="ROOM1", fire_id="PU", location=[2.0, 2.0])
         with pytest.raises(ValueError, match="Duplicate id 'FIRE1'"):
             self._make(sim_env, [room1], fires=[fire, fire_dup])
 
     def test_duplicate_device_ids(self, sim_env, room1):
         """Test that duplicate device IDs raises ValueError."""
-        dev1 = Devices.create_heat_detector("HD1", "ROOM1", [1.0, 2.0, 1.5], 70.0, 50.0)
-        dev2 = Devices.create_heat_detector("HD1", "ROOM1", [2.0, 2.0, 1.5], 70.0, 50.0)
+        dev1 = Device.create_heat_detector("HD1", "ROOM1", [1.0, 2.0, 1.5], 70.0, 50.0)
+        dev2 = Device.create_heat_detector("HD1", "ROOM1", [2.0, 2.0, 1.5], 70.0, 50.0)
         with pytest.raises(ValueError, match="Duplicate id 'HD1'"):
             self._make(sim_env, [room1], devices=[dev1, dev2])
 
     def test_duplicate_material_ids(self, sim_env, room1):
         """Test that duplicate material IDs raises ValueError."""
-        mat = MaterialProperties(id="GYPSUM", material="Gypsum Board")
-        mat_dup = MaterialProperties(id="GYPSUM", material="Gypsum Board")
+        mat = Material(id="GYPSUM", material="Gypsum Board")
+        mat_dup = Material(id="GYPSUM", material="Gypsum Board")
         with pytest.raises(ValueError, match="Duplicate id 'GYPSUM'"):
             self._make(sim_env, [room1], material_properties=[mat, mat_dup])
 
@@ -1609,12 +1603,12 @@ class TestCFASTModelValidateDependencies:
         [
             pytest.param(
                 "fires",
-                Fires(id="F1", comp_id="UNKNOWN", fire_id="PU", location=[1.0, 1.0]),
+                Fire(id="F1", comp_id="UNKNOWN", fire_id="PU", location=[1.0, 1.0]),
                 id="fire",
             ),
             pytest.param(
                 "devices",
-                Devices.create_heat_detector(
+                Device.create_heat_detector(
                     "HD1", "UNKNOWN", [1.0, 2.0, 1.5], 70.0, 50.0
                 ),
                 id="device",
@@ -1627,8 +1621,8 @@ class TestCFASTModelValidateDependencies:
             self._make(sim_env, [room1], **{component_type: [component]})
 
     def test_wall_vent_undefined_first_comp(self, sim_env, room1):
-        """Test that WallVents with undefined first compartment raises ValueError."""
-        vent = WallVents(
+        """Test that WallVent with undefined first compartment raises ValueError."""
+        vent = WallVent(
             id="V1",
             comps_ids=["UNKNOWN", "ROOM1"],
             bottom=0,
@@ -1643,8 +1637,8 @@ class TestCFASTModelValidateDependencies:
             self._make(sim_env, [room1], wall_vents=[vent])
 
     def test_wall_vent_undefined_second_comp(self, sim_env, room1):
-        """Test that WallVents with undefined second compartment raises ValueError."""
-        vent = WallVents(
+        """Test that WallVent with undefined second compartment raises ValueError."""
+        vent = WallVent(
             id="V1",
             comps_ids=["ROOM1", "UNKNOWN"],
             bottom=0,
@@ -1659,8 +1653,8 @@ class TestCFASTModelValidateDependencies:
             self._make(sim_env, [room1], wall_vents=[vent])
 
     def test_wall_vent_outside_second_comp_is_valid(self, sim_env, room1):
-        """Test that OUTSIDE as second compartment in WallVents is accepted."""
-        vent = WallVents(
+        """Test that OUTSIDE as second compartment in WallVent is accepted."""
+        vent = WallVent(
             id="V1",
             comps_ids=["ROOM1", "OUTSIDE"],
             bottom=0,
@@ -1677,12 +1671,12 @@ class TestCFASTModelValidateDependencies:
         [
             pytest.param(
                 "ceiling_floor_vents",
-                CeilingFloorVents(id="V1", comps_ids=["ROOM1", "UNKNOWN"], area=1.0),
+                CeilingFloorVent(id="V1", comps_ids=["ROOM1", "UNKNOWN"], area=1.0),
                 id="ceiling-floor-vent",
             ),
             pytest.param(
                 "mechanical_vents",
-                MechanicalVents(
+                MechanicalVent(
                     id="V1", comps_ids=["ROOM1", "UNKNOWN"], offsets=[0.0, 0.0]
                 ),
                 id="mechanical-vent",
@@ -1695,20 +1689,20 @@ class TestCFASTModelValidateDependencies:
             self._make(sim_env, [room1], **{vent_type: [vent]})
 
     def test_surface_connection_undefined_comp_id(self, sim_env, room1):
-        """Test that SurfaceConnections with undefined comp_id raises ValueError."""
-        sc = SurfaceConnections.wall_connection("UNKNOWN", "ROOM1", fraction=0.5)
+        """Test that SurfaceConnection with undefined comp_id raises ValueError."""
+        sc = SurfaceConnection.wall_connection("UNKNOWN", "ROOM1", fraction=0.5)
         with pytest.raises(ValueError, match="comp_id='UNKNOWN' does not match"):
             self._make(sim_env, [room1], surface_connections=[sc])
 
     def test_surface_connection_undefined_comp_ids(self, sim_env, room1):
-        """Test that SurfaceConnections with undefined comp_ids raises ValueError."""
-        sc = SurfaceConnections.wall_connection("ROOM1", "UNKNOWN", fraction=0.5)
+        """Test that SurfaceConnection with undefined comp_ids raises ValueError."""
+        sc = SurfaceConnection.wall_connection("ROOM1", "UNKNOWN", fraction=0.5)
         with pytest.raises(ValueError, match="comp_ids='UNKNOWN' does not match"):
             self._make(sim_env, [room1], surface_connections=[sc])
 
     def test_device_undefined_material_id(self, sim_env, room1):
         """Test that a device referencing an undefined material raises ValueError."""
-        device = Devices(
+        device = Device(
             id="T1",
             comp_id="ROOM1",
             location=[1.0, 2.0, 1.5],
@@ -1724,13 +1718,13 @@ class TestCFASTModelValidateDependencies:
     )
     def test_compartment_undefined_material_id(self, sim_env, mat_attr):
         """Test that a compartment referencing an undefined material raises ValueError."""
-        comp = Compartments(id="ROOM1", **{mat_attr: "UNKNOWN"})  # type: ignore
+        comp = Compartment(id="ROOM1", **{mat_attr: "UNKNOWN"})  # type: ignore
         with pytest.raises(ValueError, match=f"{mat_attr}='UNKNOWN' does not match"):
             self._make(sim_env, [comp])
 
     def test_fire_undefined_device_id(self, sim_env, room1):
         """Test that a fire referencing an undefined device raises ValueError."""
-        fire = Fires(
+        fire = Fire(
             id="F1",
             comp_id="ROOM1",
             fire_id="PU",
@@ -1745,7 +1739,7 @@ class TestCFASTModelValidateDependencies:
         [
             pytest.param(
                 "wall_vents",
-                WallVents(
+                WallVent(
                     id="V1",
                     comps_ids=["ROOM1", "ROOM2"],
                     bottom=0,
@@ -1760,7 +1754,7 @@ class TestCFASTModelValidateDependencies:
             ),
             pytest.param(
                 "ceiling_floor_vents",
-                CeilingFloorVents(
+                CeilingFloorVent(
                     id="V1",
                     comps_ids=["ROOM1", "ROOM2"],
                     area=1.0,
@@ -1771,7 +1765,7 @@ class TestCFASTModelValidateDependencies:
             ),
             pytest.param(
                 "mechanical_vents",
-                MechanicalVents(
+                MechanicalVent(
                     id="V1",
                     comps_ids=["ROOM1", "ROOM2"],
                     offsets=[0.0, 0.0],
@@ -1789,7 +1783,7 @@ class TestCFASTModelValidateDependencies:
 
     def test_fire_location_outside_compartment_warning(self, sim_env, room1):
         """Test that a fire outside compartment bounds raises UserWarning."""
-        fire = Fires(
+        fire = Fire(
             id="F1",
             comp_id="ROOM1",
             fire_id="PU",
@@ -1800,7 +1794,7 @@ class TestCFASTModelValidateDependencies:
 
     def test_device_location_outside_compartment_warning(self, sim_env, room1):
         """Test that a device outside compartment bounds raises UserWarning."""
-        device = Devices.create_heat_detector(
+        device = Device.create_heat_detector(
             "HD1",
             "ROOM1",
             [10.0, 10.0, 10.0],

--- a/tests/units/test_surface_connection.py
+++ b/tests/units/test_surface_connection.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import pytest
 
-from pycfast.surface_connections import SurfaceConnections
+from pycfast.surface_connection import SurfaceConnection
 
 """
-Tests for the SurfaceConnections class.
+Tests for the SurfaceConnection class.
 """
 
 
-class TestSurfaceConnections:
-    """Test class for SurfaceConnections."""
+class TestSurfaceConnection:
+    """Test class for SurfaceConnection."""
 
     def test_init_wall_connection(self):
         """Test initialization of a wall surface connection."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="WALL",
             comp_id="ROOM1",
             comp_ids="ROOM2",
@@ -27,7 +27,7 @@ class TestSurfaceConnections:
 
     def test_init_floor_connection(self):
         """Test initialization of a floor surface connection."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="FLOOR",
             comp_id="UPPER",
             comp_ids="LOWER",
@@ -39,7 +39,7 @@ class TestSurfaceConnections:
 
     def test_to_input_string_wall_connection(self):
         """Test input string generation for wall connection."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="WALL",
             comp_id="ROOM1",
             comp_ids="ROOM2",
@@ -56,7 +56,7 @@ class TestSurfaceConnections:
 
     def test_to_input_string_floor_connection(self):
         """Test input string generation for floor connection."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="FLOOR",
             comp_id="UPPER_ROOM",
             comp_ids="LOWER_ROOM",
@@ -71,12 +71,12 @@ class TestSurfaceConnections:
 
     def test_wall_connection_classmethod(self):
         """Test the wall_connection class method."""
-        conn = SurfaceConnections.wall_connection(
+        conn = SurfaceConnection.wall_connection(
             comp_id="LIVING",
             comp_ids="KITCHEN",
             fraction=0.8,
         )
-        assert isinstance(conn, SurfaceConnections)
+        assert isinstance(conn, SurfaceConnection)
         assert conn.conn_type == "WALL"
         assert conn.comp_id == "LIVING"
         assert conn.comp_ids == "KITCHEN"
@@ -84,11 +84,11 @@ class TestSurfaceConnections:
 
     def test_ceiling_floor_connection_classmethod(self):
         """Test the ceiling_floor_connection class method."""
-        conn = SurfaceConnections.ceiling_floor_connection(
+        conn = SurfaceConnection.ceiling_floor_connection(
             comp_id="SECOND_FLOOR",
             comp_ids="FIRST_FLOOR",
         )
-        assert isinstance(conn, SurfaceConnections)
+        assert isinstance(conn, SurfaceConnection)
         assert conn.conn_type == "FLOOR"
         assert conn.comp_id == "SECOND_FLOOR"
         assert conn.comp_ids == "FIRST_FLOOR"
@@ -99,13 +99,13 @@ class TestSurfaceConnections:
     )
     def test_to_input_string_wall_with_different_fractions(self, fraction: float):
         """Test input string generation for wall connections with various fraction values."""
-        conn = SurfaceConnections("WALL", "ROOM1", "ROOM2", fraction)
+        conn = SurfaceConnection("WALL", "ROOM1", "ROOM2", fraction)
         result = conn.to_input_string()
         assert f"F = {fraction}" in result
 
     def test_to_input_string_compartment_id_formatting(self):
         """Test that compartment IDs are properly quoted in output."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="WALL",
             comp_id="COMP_A",
             comp_ids="COMP_B",
@@ -118,32 +118,32 @@ class TestSurfaceConnections:
     def test_init_invalid_conn_type(self):
         """Test that initialization fails with an invalid conn_type."""
         with pytest.raises(ValueError, match="must be one of"):
-            SurfaceConnections(conn_type="CEILING", comp_id="ROOM1", comp_ids="ROOM2")
+            SurfaceConnection(conn_type="CEILING", comp_id="ROOM1", comp_ids="ROOM2")
 
     def test_init_wall_missing_fraction(self):
         """Test that WALL connection fails without a fraction value."""
         with pytest.raises(ValueError, match="WALL connection requires a fraction"):
-            SurfaceConnections(conn_type="WALL", comp_id="ROOM1", comp_ids="ROOM2")
+            SurfaceConnection(conn_type="WALL", comp_id="ROOM1", comp_ids="ROOM2")
 
     @pytest.mark.parametrize("fraction", [-0.1, 1.1])
     def test_init_wall_fraction_out_of_range(self, fraction: float):
         """Test that WALL connection fails with fraction outside [0, 1]."""
         with pytest.raises(ValueError, match=r"must be in \[0, 1\]"):
-            SurfaceConnections(
+            SurfaceConnection(
                 conn_type="WALL", comp_id="ROOM1", comp_ids="ROOM2", fraction=fraction
             )
 
     def test_init_floor_with_fraction_warning(self):
         """Test that a warning is raised when fraction is provided for a FLOOR connection."""
         with pytest.warns(UserWarning, match="fraction should be None for FLOOR"):
-            SurfaceConnections(
+            SurfaceConnection(
                 conn_type="FLOOR", comp_id="ROOM1", comp_ids="ROOM2", fraction=0.5
             )
 
     def test_to_input_string_floor_no_fraction(self):
         """Test that floor connections warn when fraction is provided and don't include it in output."""
         with pytest.warns(UserWarning, match="fraction should be None for FLOOR"):
-            conn = SurfaceConnections(
+            conn = SurfaceConnection(
                 conn_type="FLOOR",
                 comp_id="TOP",
                 comp_ids="BOTTOM",
@@ -156,12 +156,12 @@ class TestSurfaceConnections:
     # Tests for dunder methods
     def test_repr(self) -> None:
         """Test __repr__ method."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="WALL", comp_id="ROOM1", comp_ids="ROOM2", fraction=0.75
         )
 
         repr_str = repr(conn)
-        assert "SurfaceConnections(" in repr_str
+        assert "SurfaceConnection(" in repr_str
         assert "conn_type='WALL'" in repr_str
         assert "comp_id='ROOM1'" in repr_str
         assert "comp_ids='ROOM2'" in repr_str
@@ -169,18 +169,18 @@ class TestSurfaceConnections:
 
     def test_repr_floor_connection(self) -> None:
         """Test __repr__ method for floor connection."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="FLOOR", comp_id="UPPER", comp_ids="LOWER", fraction=None
         )
 
         repr_str = repr(conn)
-        assert "SurfaceConnections(" in repr_str
+        assert "SurfaceConnection(" in repr_str
         assert "conn_type='FLOOR'" in repr_str
         assert "fraction=None" in repr_str
 
     def test_str(self) -> None:
         """Test __str__ method."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="WALL", comp_id="LIVING_ROOM", comp_ids="KITCHEN", fraction=0.6
         )
 
@@ -190,7 +190,7 @@ class TestSurfaceConnections:
 
     def test_str_floor_connection(self) -> None:
         """Test __str__ method for floor connection."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="FLOOR",
             comp_id="SECOND_FLOOR",
             comp_ids="FIRST_FLOOR",
@@ -203,7 +203,7 @@ class TestSurfaceConnections:
 
     def test_getitem(self) -> None:
         """Test __getitem__ method."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="WALL", comp_id="ROOM_A", comp_ids="ROOM_B", fraction=0.8
         )
 
@@ -214,16 +214,16 @@ class TestSurfaceConnections:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        conn = SurfaceConnections("WALL", "A", "B", 0.5)
+        conn = SurfaceConnection("WALL", "A", "B", 0.5)
 
         with pytest.raises(
-            KeyError, match="Property 'invalid_key' not found in SurfaceConnections"
+            KeyError, match="Property 'invalid_key' not found in SurfaceConnection"
         ):
             conn["invalid_key"]
 
     def test_setitem(self) -> None:
         """Test __setitem__ method."""
-        conn = SurfaceConnections("WALL", "A", "B", 0.5)
+        conn = SurfaceConnection("WALL", "A", "B", 0.5)
 
         # Test setting various properties
         conn["conn_type"] = "FLOOR"
@@ -240,7 +240,7 @@ class TestSurfaceConnections:
 
     def test_setitem_invalid_does_not_mutate_state(self) -> None:
         """Test that a failed __setitem__ rolls back to the previous value."""
-        conn = SurfaceConnections("WALL", "A", "B", 0.5)
+        conn = SurfaceConnection("WALL", "A", "B", 0.5)
 
         with pytest.raises(ValueError):
             conn["conn_type"] = "INNVALID_CONN_TYPE"
@@ -249,14 +249,14 @@ class TestSurfaceConnections:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        conn = SurfaceConnections("WALL", "A", "B", 0.5)
+        conn = SurfaceConnection("WALL", "A", "B", 0.5)
 
         with pytest.raises(KeyError, match="Cannot set 'invalid_key'"):
             conn["invalid_key"] = "value"
 
     def test_repr_html(self) -> None:
         """Test _repr_html_ method."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="WALL", comp_id="ROOM1", comp_ids="ROOM2", fraction=0.75
         )
 
@@ -275,7 +275,7 @@ class TestSurfaceConnections:
 
     def test_repr_html_floor_connection(self) -> None:
         """Test _repr_html_ method for floor connection."""
-        conn = SurfaceConnections(
+        conn = SurfaceConnection(
             conn_type="FLOOR", comp_id="UPPER", comp_ids="LOWER", fraction=None
         )
 

--- a/tests/units/test_wall_vent.py
+++ b/tests/units/test_wall_vent.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import pytest
 
-from pycfast.wall_vents import WallVents
+from pycfast.wall_vent import WallVent
 
 """
-Tests for the WallVents class.
+Tests for the WallVent class.
 """
 
 
 @pytest.fixture()
 def make_wall_vent():
-    """Create a WallVents instance with sensible defaults."""
+    """Create a WallVent instance with sensible defaults."""
 
-    def _make(**kwargs: object) -> WallVents:
+    def _make(**kwargs: object) -> WallVent:
         defaults: dict[str, object] = {
             "id": "DOOR1",
             "comps_ids": ["ROOM1", "ROOM2"],
@@ -24,17 +24,17 @@ def make_wall_vent():
             "offset": 1.0,
         }
         defaults.update(kwargs)
-        return WallVents(**defaults)  # type: ignore[arg-type]
+        return WallVent(**defaults)  # type: ignore[arg-type]
 
     return _make
 
 
-class TestWallVents:
-    """Test class for WallVents."""
+class TestWallVent:
+    """Test class for WallVent."""
 
     def test_init_basic(self):
         """Test basic initialization with required parameters."""
-        vent = WallVents(
+        vent = WallVent(
             id="DOOR1",
             comps_ids=["ROOM1", "ROOM2"],
             bottom=0.0,
@@ -60,7 +60,7 @@ class TestWallVents:
 
     def test_init_with_all_parameters(self):
         """Test initialization with all parameters."""
-        vent = WallVents(
+        vent = WallVent(
             id="DOOR1",
             comps_ids=["ROOM1", "ROOM2"],
             bottom=0.0,
@@ -94,7 +94,7 @@ class TestWallVents:
     def test_init_default_values(self):
         """Test initialization with default values (zero height/width warns about no flow)."""
         with pytest.warns(UserWarning, match="height or width is 0"):
-            vent = WallVents(id="DOOR1", comps_ids=["ROOM1", "ROOM2"])
+            vent = WallVent(id="DOOR1", comps_ids=["ROOM1", "ROOM2"])
         assert vent.bottom == 0
         assert vent.height == 0
         assert vent.width == 0
@@ -111,12 +111,12 @@ class TestWallVents:
     def test_init_invalid_comps_ids_length(self, comps_ids: list[str]):
         """Test that initialization fails with wrong number of compartments."""
         with pytest.raises(ValueError, match="exactly 2 compartments"):
-            WallVents(id="DOOR1", comps_ids=comps_ids)
+            WallVent(id="DOOR1", comps_ids=comps_ids)
 
     def test_init_outside_as_first_compartment(self):
         """Test error when OUTSIDE is the first compartment."""
         with pytest.raises(ValueError, match="Compartment order is incorrect"):
-            WallVents(id="DOOR1", comps_ids=["OUTSIDE", "ROOM1"])
+            WallVent(id="DOOR1", comps_ids=["OUTSIDE", "ROOM1"])
 
     @pytest.mark.parametrize("param", ["height", "width", "bottom"])
     def test_init_negative_dimension(self, make_wall_vent, param: str):
@@ -138,7 +138,7 @@ class TestWallVents:
     def test_init_mismatched_time_fraction_lists(self):
         """Test that initialization fails with mismatched time and fraction lists."""
         with pytest.raises(ValueError, match="equal length"):
-            WallVents(
+            WallVent(
                 id="DOOR1",
                 comps_ids=["ROOM1", "ROOM2"],
                 time=[0.0, 100.0],
@@ -163,7 +163,7 @@ class TestWallVents:
 
     def test_to_input_string_with_outside(self):
         """Test input string generation with outside compartment."""
-        vent = WallVents(
+        vent = WallVent(
             id="WINDOW1",
             comps_ids=["ROOM1", "OUTSIDE"],
             bottom=1.0,
@@ -295,7 +295,7 @@ class TestWallVents:
 
     def test_to_input_string_complex_scenario(self):
         """Test input string generation with all options combined."""
-        vent = WallVents(
+        vent = WallVent(
             id="COMPLEX_DOOR",
             comps_ids=["LIVING", "KITCHEN"],
             bottom=0.1,
@@ -331,7 +331,7 @@ class TestWallVents:
 
     def test_compartment_ids_formatting(self):
         """Test that compartment IDs are properly quoted in output."""
-        vent = WallVents(
+        vent = WallVent(
             id="TEST_VENT",
             comps_ids=["COMP_A", "COMP_B"],
             bottom=0.0,
@@ -346,7 +346,7 @@ class TestWallVents:
     # Tests for dunder methods
     def test_repr(self) -> None:
         """Test __repr__ method."""
-        vent = WallVents(
+        vent = WallVent(
             id="DOOR_MAIN",
             comps_ids=["LIVING_ROOM", "KITCHEN"],
             bottom=0.0,
@@ -359,7 +359,7 @@ class TestWallVents:
         )
 
         repr_str = repr(vent)
-        assert "WallVents(" in repr_str
+        assert "WallVent(" in repr_str
         assert "id='DOOR_MAIN'" in repr_str
         assert "comps_ids=['LIVING_ROOM', 'KITCHEN']" in repr_str
         assert "bottom=0.0" in repr_str
@@ -369,7 +369,7 @@ class TestWallVents:
 
     def test_str(self) -> None:
         """Test __str__ method."""
-        vent = WallVents(
+        vent = WallVent(
             id="WINDOW_01",
             comps_ids=["BEDROOM", "OUTSIDE"],
             bottom=1.0,
@@ -389,7 +389,7 @@ class TestWallVents:
 
     def test_getitem(self) -> None:
         """Test __getitem__ method."""
-        vent = WallVents(
+        vent = WallVent(
             id="TEST_VENT",
             comps_ids=["COMP1", "COMP2"],
             bottom=0.5,
@@ -419,7 +419,7 @@ class TestWallVents:
 
     def test_getitem_invalid_key(self) -> None:
         """Test __getitem__ method with invalid key."""
-        vent = WallVents(
+        vent = WallVent(
             id="VENT1",
             comps_ids=["A", "B"],
             bottom=0.0,
@@ -430,13 +430,13 @@ class TestWallVents:
         )
 
         with pytest.raises(
-            KeyError, match="Property 'invalid_key' not found in WallVents"
+            KeyError, match="Property 'invalid_key' not found in WallVent"
         ):
             vent["invalid_key"]
 
     def test_setitem(self) -> None:
         """Test __setitem__ method."""
-        vent = WallVents(
+        vent = WallVent(
             id="VENT1",
             comps_ids=["A", "B"],
             bottom=0.0,
@@ -470,7 +470,7 @@ class TestWallVents:
 
     def test_setitem_invalid_key(self) -> None:
         """Test __setitem__ method with invalid key."""
-        vent = WallVents(
+        vent = WallVent(
             id="VENT1",
             comps_ids=["A", "B"],
             bottom=0.0,
@@ -485,7 +485,7 @@ class TestWallVents:
 
     def test_repr_html(self) -> None:
         """Test _repr_html_ method."""
-        vent = WallVents(
+        vent = WallVent(
             id="DOOR_MAIN",
             comps_ids=["LIVING_ROOM", "KITCHEN"],
             bottom=0.0,
@@ -515,7 +515,7 @@ class TestWallVents:
         assert "1.5" in html_str  # offset
 
 
-class TestWallVentsSetItemValidation:
+class TestWallVentSetItemValidation:
     """Test validation in __setitem__ to ensure data integrity."""
 
     @pytest.mark.parametrize(

--- a/tests/verification_tests/test_DOE_Guidance_Report.py
+++ b/tests/verification_tests/test_DOE_Guidance_Report.py
@@ -6,11 +6,11 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -41,7 +41,7 @@ def test_doe201_no_fire_simulation(tmp_path):
         exterior_temperature=20,
     )
     material_properties = [
-        MaterialProperties(
+        Material(
             id="GYPS000",
             material="Gypsum for DOE sample problem",
             conductivity=0.2,
@@ -50,7 +50,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             thickness=0.016,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="CONC003",
             material="Concrete for DOE sample problem",
             conductivity=1.75,
@@ -61,7 +61,7 @@ def test_doe201_no_fire_simulation(tmp_path):
         ),
     ]
     compartments = [
-        Compartments(
+        Compartment(
             id="Process Room",
             depth=3,
             height=2.6,
@@ -76,7 +76,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Airlock",
             depth=2,
             height=2.44,
@@ -91,7 +91,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             origin_y=1,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Corridor",
             depth=3,
             height=2.44,
@@ -108,7 +108,7 @@ def test_doe201_no_fire_simulation(tmp_path):
         ),
     ]
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Process Room", "Airlock"],
             bottom=0,
@@ -117,7 +117,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             face="RIGHT",
             offset=1.2,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Process Room", "Airlock"],
             bottom=0,
@@ -129,7 +129,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             time=[0, 0],
             fraction=[0, 0],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_3",
             comps_ids=["Process Room", "Corridor"],
             bottom=0.9,
@@ -141,7 +141,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             time=[0, 0],
             fraction=[0, 0],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_4",
             comps_ids=["Process Room", "Corridor"],
             bottom=2.3,
@@ -150,7 +150,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             face="REAR",
             offset=1,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_5",
             comps_ids=["Airlock", "Corridor"],
             bottom=0,
@@ -159,7 +159,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             face="REAR",
             offset=0.2,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_6",
             comps_ids=["Airlock", "Corridor"],
             bottom=0,
@@ -171,7 +171,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             time=[0, 0],
             fraction=[0, 0],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_7",
             comps_ids=["Corridor", "OUTSIDE"],
             bottom=0,
@@ -180,7 +180,7 @@ def test_doe201_no_fire_simulation(tmp_path):
             face="REAR",
             offset=13.5,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_8",
             comps_ids=["Corridor", "OUTSIDE"],
             bottom=0,
@@ -194,7 +194,7 @@ def test_doe201_no_fire_simulation(tmp_path):
         ),
     ]
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["Process Room", "OUTSIDE"],
             area=[0.05, 0.05],

--- a/tests/verification_tests/test_NRC_A_cabinet_fire_in_mcr.py
+++ b/tests/verification_tests/test_NRC_A_cabinet_fire_in_mcr.py
@@ -7,13 +7,13 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -45,7 +45,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="MCROperator",
             material="MCR Operator (properties of water at 20 C)",
             conductivity=0.58,
@@ -54,7 +54,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             thickness=0.2032,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="MCRConcrete",
             material="MCR Concrete Floor (user''s guide)",
             conductivity=1.6,
@@ -63,7 +63,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             thickness=0.5,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="MCRConcreteW",
             material="MCR Concrete Wall (user''s guide)",
             conductivity=1.6,
@@ -72,7 +72,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             thickness=0.9,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="MCRGypsum",
             material="MCR Gypsum Walls (user''s guide)",
             conductivity=0.17,
@@ -84,7 +84,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="MCR",
             depth=13.8,
             height=5.2,
@@ -102,7 +102,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["MCR", "OUTSIDE"],
             bottom=0,
@@ -114,7 +114,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["MCR", "OUTSIDE"],
             area=[0.36, 0.36],
@@ -129,7 +129,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["MCR", "OUTSIDE"],
             area=[0.36, 0.36],
@@ -144,7 +144,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_3",
             comps_ids=["OUTSIDE", "MCR"],
             area=[0.36, 0.36],
@@ -159,7 +159,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_4",
             comps_ids=["OUTSIDE", "MCR"],
             area=[0.36, 0.36],
@@ -174,7 +174,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_5",
             comps_ids=["OUTSIDE", "MCR"],
             area=[0.36, 0.36],
@@ -189,7 +189,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_6",
             comps_ids=["OUTSIDE", "MCR"],
             area=[0.36, 0.36],
@@ -204,7 +204,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_7",
             comps_ids=["OUTSIDE", "MCR"],
             area=[0.36, 0.36],
@@ -219,7 +219,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_8",
             comps_ids=["OUTSIDE", "MCR"],
             area=[0.36, 0.36],
@@ -237,7 +237,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="XPE_Neoprene 702 kW",
             comp_id="MCR",
             fire_id="XPE_Neoprene 702 kW_Fire",
@@ -269,7 +269,7 @@ def test_cabinet_fire_in_mcr_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="MCR",
             location=[11.2, 5.5, 1.524],
@@ -323,7 +323,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="MCROperator",
             material="MCR Operator (properties of water at 20 C)",
             conductivity=0.58,
@@ -332,7 +332,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
             thickness=0.2032,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="MCRConcrete",
             material="MCR Concrete Floor (user''s guide)",
             conductivity=1.6,
@@ -341,7 +341,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
             thickness=0.5,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="MCRConcreteW",
             material="MCR Concrete Wall (user''s guide)",
             conductivity=1.6,
@@ -350,7 +350,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
             thickness=0.9,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="MCRGypsum",
             material="MCR Gypsum Walls (user''s guide)",
             conductivity=0.17,
@@ -362,7 +362,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="MCR",
             depth=13.8,
             height=5.2,
@@ -380,7 +380,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["MCR", "OUTSIDE"],
             bottom=0,
@@ -392,7 +392,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="XPE_Neoprene 702 kW",
             comp_id="MCR",
             fire_id="XPE_Neoprene 702 kW_Fire",
@@ -424,7 +424,7 @@ def test_cabinet_fire_in_mcr_no_ventilation_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="MCR",
             location=[11.2, 5.5, 1.524],

--- a/tests/verification_tests/test_NRC_B_cabinet_fire_in_switchgear.py
+++ b/tests/verification_tests/test_NRC_B_cabinet_fire_in_switchgear.py
@@ -7,13 +7,13 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -46,7 +46,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="CABSWConcrete",
             material="Cabinet Switchgear Concrete Floor (user''s guide)",
             conductivity=1.6,
@@ -55,7 +55,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             thickness=0.5,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="CABSWSteel",
             material="Cabinet Switchgear Steel Cabinet (user''s guide)",
             conductivity=48,
@@ -64,7 +64,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             thickness=0.0015,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="THIEF",
             material="Thief Cable (per NUREG CR 6931)",
             conductivity=0.2,
@@ -76,7 +76,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Switchgear Room",
             depth=18.5,
             height=6.1,
@@ -94,7 +94,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             bottom=0,
@@ -106,7 +106,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Switchgear Room"],
             area=[0.3, 0.3],
@@ -118,7 +118,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["OUTSIDE", "Switchgear Room"],
             area=[0.3, 0.3],
@@ -130,7 +130,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_3",
             comps_ids=["OUTSIDE", "Switchgear Room"],
             area=[0.3, 0.3],
@@ -142,7 +142,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_4",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             area=[0.3, 0.3],
@@ -154,7 +154,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_5",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             area=[0.3, 0.3],
@@ -166,7 +166,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_6",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             area=[0.3, 0.3],
@@ -181,7 +181,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="PE_PVC 464 kW",
             comp_id="Switchgear Room",
             fire_id="PE_PVC 464 kW_Fire",
@@ -210,7 +210,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
                 [1930, 0, 2.4, 0.18, 0.147, 0.136, 0, 0.4026547, 0],
             ],
         ),
-        Fires(
+        Fire(
             id="MCC Cable Tray Secondary Fire",
             comp_id="Switchgear Room",
             fire_id="MCC Cable Tray Secondary Fire_Fire",
@@ -255,7 +255,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Switchgear Room",
             location=[8.3, 7, 2.4],
@@ -265,7 +265,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             temperature_depth=0.00075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Switchgear Room",
             location=[8.3, 12, 2.4],
@@ -275,7 +275,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             temperature_depth=0.00075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3",
             comp_id="Switchgear Room",
             location=[8.3, 9.5, 3.9],
@@ -285,7 +285,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             temperature_depth=0.003,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4",
             comp_id="Switchgear Room",
             location=[8.3, 9.5, 4.4],
@@ -295,7 +295,7 @@ def test_cabinet_fire_in_switchgear_simulation(tmp_path):
             temperature_depth=0.003,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5",
             comp_id="Switchgear Room",
             location=[8.3, 9.5, 4.9],
@@ -349,7 +349,7 @@ def test_initial_fire_only_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="CABSWConcrete",
             material="Cabinet Switchgear Concrete Floor (user''s guide)",
             conductivity=1.6,
@@ -358,7 +358,7 @@ def test_initial_fire_only_simulation(tmp_path):
             thickness=0.5,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="CABSWSteel",
             material="Cabinet Switchgear Steel Cabinet (user''s guide)",
             conductivity=48,
@@ -367,7 +367,7 @@ def test_initial_fire_only_simulation(tmp_path):
             thickness=0.0015,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="THIEF",
             material="Thief Cable (per NUREG CR 6931)",
             conductivity=0.2,
@@ -379,7 +379,7 @@ def test_initial_fire_only_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Switchgear Room",
             depth=18.5,
             height=6.1,
@@ -397,7 +397,7 @@ def test_initial_fire_only_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             bottom=0,
@@ -409,7 +409,7 @@ def test_initial_fire_only_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Switchgear Room"],
             area=[0.3, 0.3],
@@ -421,7 +421,7 @@ def test_initial_fire_only_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["OUTSIDE", "Switchgear Room"],
             area=[0.3, 0.3],
@@ -433,7 +433,7 @@ def test_initial_fire_only_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_3",
             comps_ids=["OUTSIDE", "Switchgear Room"],
             area=[0.3, 0.3],
@@ -445,7 +445,7 @@ def test_initial_fire_only_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_4",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             area=[0.3, 0.3],
@@ -457,7 +457,7 @@ def test_initial_fire_only_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_5",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             area=[0.3, 0.3],
@@ -469,7 +469,7 @@ def test_initial_fire_only_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_6",
             comps_ids=["Switchgear Room", "OUTSIDE"],
             area=[0.3, 0.3],
@@ -484,7 +484,7 @@ def test_initial_fire_only_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="PE_PVC 464 kW",
             comp_id="Switchgear Room",
             fire_id="PE_PVC 464 kW_Fire",
@@ -516,7 +516,7 @@ def test_initial_fire_only_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Switchgear Room",
             location=[8.3, 7, 2.4],
@@ -526,7 +526,7 @@ def test_initial_fire_only_simulation(tmp_path):
             temperature_depth=0.00075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Switchgear Room",
             location=[8.3, 12, 2.4],
@@ -536,7 +536,7 @@ def test_initial_fire_only_simulation(tmp_path):
             temperature_depth=0.00075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3",
             comp_id="Switchgear Room",
             location=[8.3, 9.5, 3.9],
@@ -546,7 +546,7 @@ def test_initial_fire_only_simulation(tmp_path):
             temperature_depth=0.003,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4",
             comp_id="Switchgear Room",
             location=[8.3, 9.5, 4.4],
@@ -556,7 +556,7 @@ def test_initial_fire_only_simulation(tmp_path):
             temperature_depth=0.003,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5",
             comp_id="Switchgear Room",
             location=[8.3, 9.5, 4.9],

--- a/tests/verification_tests/test_NRC_D_mcc_fire_in_switchgear.py
+++ b/tests/verification_tests/test_NRC_D_mcc_fire_in_switchgear.py
@@ -7,13 +7,13 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -46,7 +46,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="SwMCCConcrete",
             material="Switchgear MCC Concrete (user''s guide)",
             conductivity=1.6,
@@ -55,7 +55,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             thickness=0.6,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="SwMCCSteel",
             material="Switchgear MCC Steel (user''s guide)",
             conductivity=54,
@@ -64,7 +64,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             thickness=0.0015,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="THIEF",
             material="Thief Cable (per NUREG CR 6931)",
             conductivity=0.2,
@@ -76,7 +76,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Low Ceiling Area",
             depth=8.5,
             height=3,
@@ -91,7 +91,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="High Ceiling Area",
             depth=8.5,
             height=9.1,
@@ -109,7 +109,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Low Ceiling Area", "High Ceiling Area"],
             bottom=0,
@@ -118,7 +118,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             face="RIGHT",
             offset=0,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["High Ceiling Area", "OUTSIDE"],
             bottom=0,
@@ -127,7 +127,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             face="FRONT",
             offset=5.97,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_3",
             comps_ids=["Low Ceiling Area", "OUTSIDE"],
             bottom=0,
@@ -139,7 +139,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Low Ceiling Area"],
             area=[0.2, 0.2],
@@ -150,7 +150,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["High Ceiling Area", "OUTSIDE"],
             area=[0.2, 0.2],
@@ -164,7 +164,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="MCC 702 kW",
             comp_id="Low Ceiling Area",
             fire_id="MCC 702 kW_Fire",
@@ -196,7 +196,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Low Ceiling Area",
             location=[2.8, 4.15, 2.6],
@@ -206,7 +206,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             temperature_depth=0.00405,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Low Ceiling Area",
             location=[3, 5.5, 2.6],
@@ -216,7 +216,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             temperature_depth=0.00405,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3",
             comp_id="High Ceiling Area",
             location=[4.25, 4.25, 9],
@@ -226,7 +226,7 @@ def test_mcc_in_switchgear_simulation(tmp_path):
             temperature_depth=0.00405,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4",
             comp_id="Low Ceiling Area",
             location=[3.5, 5, 2.4],
@@ -280,7 +280,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="SwMCCConcrete",
             material="Switchgear MCC Concrete (user''s guide)",
             conductivity=1.6,
@@ -289,7 +289,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
             thickness=0.6,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="SwMCCSteel",
             material="Switchgear MCC Steel (user''s guide)",
             conductivity=54,
@@ -298,7 +298,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
             thickness=0.0015,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="THIEF",
             material="Thief Cable (per NUREG CR 6931)",
             conductivity=0.2,
@@ -310,7 +310,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Low Ceiling Area",
             depth=8.5,
             height=9.1,
@@ -330,7 +330,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Low Ceiling Area", "OUTSIDE"],
             bottom=0,
@@ -339,7 +339,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
             face="FRONT",
             offset=8.05,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_3",
             comps_ids=["Low Ceiling Area", "OUTSIDE"],
             bottom=0,
@@ -351,7 +351,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Low Ceiling Area"],
             area=[0.2, 0.2],
@@ -362,7 +362,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["Low Ceiling Area", "OUTSIDE"],
             area=[0.2, 0.2],
@@ -376,7 +376,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="MCC 702 kW",
             comp_id="Low Ceiling Area",
             fire_id="MCC 702 kW_Fire",
@@ -408,7 +408,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Low Ceiling Area",
             location=[2.8, 4.15, 2.6],
@@ -418,7 +418,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
             temperature_depth=0.00405,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Low Ceiling Area",
             location=[3, 5.5, 2.6],
@@ -428,7 +428,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
             temperature_depth=0.00405,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3",
             comp_id="Low Ceiling Area",
             location=[8.6, 4.25, 9],
@@ -438,7 +438,7 @@ def test_mcc_in_switchgear_one_compartment_simulation(tmp_path):
             temperature_depth=0.00405,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4",
             comp_id="Low Ceiling Area",
             location=[3.5, 5, 2.4],

--- a/tests/verification_tests/test_NRC_E_trash_fire_in_cable_spreading_room.py
+++ b/tests/verification_tests/test_NRC_E_trash_fire_in_cable_spreading_room.py
@@ -7,13 +7,13 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -46,7 +46,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="CSRConcrete",
             material="CSR Concrete (user''s guide)",
             conductivity=1.6,
@@ -55,7 +55,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             thickness=0.5,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="THIEF",
             material="Thief Cable (per NUREG CR 6931)",
             conductivity=0.2,
@@ -67,7 +67,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Cable Spreading Room",
             depth=18.5,
             height=4,
@@ -117,7 +117,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Cable Spreading Room", "OUTSIDE"],
             bottom=0,
@@ -126,7 +126,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             face="FRONT",
             offset=5,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Cable Spreading Room", "OUTSIDE"],
             bottom=0,
@@ -135,7 +135,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             face="FRONT",
             offset=33,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_3",
             comps_ids=["Cable Spreading Room", "OUTSIDE"],
             bottom=0.01,
@@ -150,7 +150,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Cable Spreading Room"],
             area=[0.25, 0.25],
@@ -165,7 +165,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["OUTSIDE", "Cable Spreading Room"],
             area=[0.25, 0.25],
@@ -180,7 +180,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_3",
             comps_ids=["Cable Spreading Room", "OUTSIDE"],
             area=[0.25, 0.25],
@@ -195,7 +195,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_4",
             comps_ids=["Cable Spreading Room", "OUTSIDE"],
             area=[0.25, 0.25],
@@ -213,7 +213,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Transient Combustibles",
             comp_id="Cable Spreading Room",
             fire_id="Transient Combustibles_Fire",
@@ -245,7 +245,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Cable Spreading Room",
             location=[33, 16.3, 1.8],
@@ -255,7 +255,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             temperature_depth=0.0001125,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Cable Spreading Room",
             location=[33, 16.3, 2.3],
@@ -265,7 +265,7 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             temperature_depth=0.0001125,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3",
             comp_id="Cable Spreading Room",
             location=[33, 16.3, 3.1],
@@ -275,98 +275,98 @@ def test_trash_fire_in_cable_spreading_room_simulation(tmp_path):
             temperature_depth=0.0001125,
             depth_units="M",
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_1",
             comp_id="Cable Spreading Room",
             location=[4, 15.5, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_2",
             comp_id="Cable Spreading Room",
             location=[11.9, 15.5, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_3",
             comp_id="Cable Spreading Room",
             location=[19.8, 15.5, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_4",
             comp_id="Cable Spreading Room",
             location=[27.7, 15.5, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_5",
             comp_id="Cable Spreading Room",
             location=[35.7, 15.5, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_6",
             comp_id="Cable Spreading Room",
             location=[4, 9.4, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_7",
             comp_id="Cable Spreading Room",
             location=[11.9, 9.4, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_8",
             comp_id="Cable Spreading Room",
             location=[27.7, 9.4, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_9",
             comp_id="Cable Spreading Room",
             location=[35.7, 9.4, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_10",
             comp_id="Cable Spreading Room",
             location=[4, 3.3, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_11",
             comp_id="Cable Spreading Room",
             location=[11.9, 3.3, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_12",
             comp_id="Cable Spreading Room",
             location=[19.8, 3.3, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_13",
             comp_id="Cable Spreading Room",
             location=[27.7, 3.3, 3.96],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_14",
             comp_id="Cable Spreading Room",
             location=[35.7, 3.3, 3.96],

--- a/tests/verification_tests/test_NRC_G_transient_fire_in_corridor.py
+++ b/tests/verification_tests/test_NRC_G_transient_fire_in_corridor.py
@@ -7,13 +7,13 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -46,7 +46,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="CorConcrete",
             material="Corridor Concrete (User''s Guide)",
             conductivity=1.6,
@@ -55,7 +55,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             thickness=0.5,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="CorXPE",
             material="Corridor XPE Cable (NUREG 1824)",
             conductivity=0.21,
@@ -67,7 +67,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Compartment 1",
             depth=4.1,
             height=6.1,
@@ -83,7 +83,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Compartment 2",
             depth=23.4,
             height=6.1,
@@ -98,7 +98,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Compartment 3",
             depth=4.1,
             height=6.1,
@@ -113,7 +113,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Compartment 4",
             depth=6,
             height=6.1,
@@ -128,7 +128,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             origin_y=4.1,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Compartment 5",
             depth=6.6,
             height=6.1,
@@ -143,7 +143,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             origin_y=10.1,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Compartment 6",
             depth=6.6,
             height=6.1,
@@ -158,7 +158,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             origin_y=16.7,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Compartment 7",
             depth=8.2,
             height=6.1,
@@ -173,7 +173,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Compartment 8",
             depth=15.2,
             height=6.1,
@@ -192,7 +192,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
 
     wall_vents = [
         # Inter-compartment connections
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Compartment 1", "Compartment 2"],
             bottom=0,
@@ -201,7 +201,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="RIGHT",
             offset=0,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Compartment 2", "Compartment 3"],
             bottom=0,
@@ -210,7 +210,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="RIGHT",
             offset=0,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_3",
             comps_ids=["Compartment 3", "Compartment 4"],
             bottom=0,
@@ -219,7 +219,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="REAR",
             offset=10.6,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_4",
             comps_ids=["Compartment 4", "Compartment 5"],
             bottom=0,
@@ -228,7 +228,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="REAR",
             offset=0,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_5",
             comps_ids=["Compartment 5", "Compartment 6"],
             bottom=0,
@@ -237,7 +237,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="REAR",
             offset=4.2,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_6",
             comps_ids=["Compartment 3", "Compartment 7"],
             bottom=0,
@@ -246,7 +246,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="RIGHT",
             offset=0,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_7",
             comps_ids=["Compartment 7", "Compartment 8"],
             bottom=0,
@@ -256,7 +256,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             offset=9.2,
         ),
         # External leakage vents
-        WallVents(
+        WallVent(
             id="WallVent_8",
             comps_ids=["Compartment 1", "OUTSIDE"],
             bottom=0,
@@ -265,7 +265,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="LEFT",
             offset=0,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_9",
             comps_ids=["Compartment 2", "OUTSIDE"],
             bottom=0,
@@ -274,7 +274,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             face="REAR",
             offset=0,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_10",
             comps_ids=["Compartment 8", "OUTSIDE"],
             bottom=0,
@@ -286,7 +286,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Compartment 1"],
             area=[1, 1],
@@ -297,7 +297,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["Compartment 7", "OUTSIDE"],
             area=[1, 1],
@@ -311,7 +311,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Transient Combustibles",
             comp_id="Compartment 8",
             fire_id="Pallets",
@@ -342,7 +342,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Compartment 2",
             location=[1, 0.45, 4.8],
@@ -352,7 +352,7 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             temperature_depth=0.0015,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Compartment 6",
             location=[5.2, 4.15, 4.8],
@@ -362,56 +362,56 @@ def test_transient_fire_in_corridor_simulation(tmp_path):
             temperature_depth=0.0015,
             depth_units="M",
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_1",
             comp_id="Compartment 1",
             location=[1.5, 1.6, 6.039],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_2",
             comp_id="Compartment 3",
             location=[2.6, 2.05, 6.039],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_3",
             comp_id="Compartment 3",
             location=[11.9, 2.05, 6.039],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_4",
             comp_id="Compartment 3",
             location=[39.9, 2.05, 6.039],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_5",
             comp_id="Compartment 5",
             location=[5.15, 3.3, 6.039],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_6",
             comp_id="Compartment 6",
             location=[5.3, 3.3, 6.039],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_7",
             comp_id="Compartment 7",
             location=[6.1, 4.1, 6.039],
             setpoint=30,
             rti=5,
         ),
-        Devices.create_heat_detector(
+        Device.create_heat_detector(
             id="HeatDetector_8",
             comp_id="Compartment 8",
             location=[1.5, 10.2, 6.039],

--- a/tests/verification_tests/test_energy_balance.py
+++ b/tests/verification_tests/test_energy_balance.py
@@ -6,8 +6,8 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Fires,
+    Compartment,
+    Fire,
     SimulationEnvironment,
 )
 
@@ -41,7 +41,7 @@ def test_sealed_test_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Compartment 1",
             depth=5,
             height=5,
@@ -57,7 +57,7 @@ def test_sealed_test_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="100 kW",
             comp_id="Compartment 1",
             fire_id="100 kW_Fire",
@@ -117,7 +117,7 @@ def test_sealed_test_2_layers_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Compartment 1",
             depth=5,
             height=5,
@@ -133,7 +133,7 @@ def test_sealed_test_2_layers_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="100 kW",
             comp_id="Compartment 1",
             fire_id="100 kW_Fire",

--- a/tests/verification_tests/test_error.py
+++ b/tests/verification_tests/test_error.py
@@ -4,11 +4,11 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 
@@ -28,7 +28,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
         exterior_temperature=20,
     )
     material_properties = [
-        MaterialProperties(
+        Material(
             id="GYPS000",
             material="Gypsum for DOE sample problem",
             conductivity=0.2,
@@ -37,7 +37,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             thickness=0.016,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="CONC003",
             material="Concrete for DOE sample problem",
             conductivity=1.75,
@@ -48,7 +48,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
         ),
     ]
     compartments = [
-        Compartments(
+        Compartment(
             id="Process Room",
             depth=3,
             height=2.6,
@@ -63,7 +63,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Airlock",
             depth=2,
             height=2.44,
@@ -78,7 +78,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             origin_y=1,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Corridor",
             depth=3,
             height=2.44,
@@ -95,7 +95,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
         ),
     ]
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Process Room", "Airlock"],
             bottom=0,
@@ -104,7 +104,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             face="RIGHT",
             offset=1.2,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Process Room", "Airlock"],
             bottom=0,
@@ -116,7 +116,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             time=[0, 0],
             fraction=[0, 0],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_3",
             comps_ids=["Process Room", "Corridor"],
             bottom=0.9,
@@ -128,7 +128,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             time=[0, 0],
             fraction=[0, 0],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_4",
             comps_ids=["Process Room", "Corridor"],
             bottom=2.3,
@@ -137,7 +137,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             face="REAR",
             offset=1,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_5",
             comps_ids=["Airlock", "Corridor"],
             bottom=0,
@@ -146,7 +146,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             face="REAR",
             offset=0.2,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_6",
             comps_ids=["Airlock", "Corridor"],
             bottom=0,
@@ -158,7 +158,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             time=[0, 0],
             fraction=[0, 0],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_7",
             comps_ids=["Corridor", "OUTSIDE"],
             bottom=0,
@@ -167,7 +167,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
             face="REAR",
             offset=13.5,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_8",
             comps_ids=["Corridor", "OUTSIDE"],
             bottom=0,
@@ -181,7 +181,7 @@ def test_doe201_no_fire_simulation_with_error(tmp_path):
         ),
     ]
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["Invalid Room", "OUTSIDE"],  # misspelled compartment name
             area=[0.05, 0.05],

--- a/tests/verification_tests/test_fires.py
+++ b/tests/verification_tests/test_fires.py
@@ -6,12 +6,12 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
+    Compartment,
+    Device,
+    Fire,
+    Material,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -21,7 +21,7 @@ from .verification import (
 
 pytestmark = [pytest.mark.slow, pytest.mark.local]
 
-verification_data_dir = get_verification_data_dir(Path(__file__).parent, "Fires")
+verification_data_dir = get_verification_data_dir(Path(__file__).parent, "Fire")
 
 
 def test_ignition_test_simulation(tmp_path):
@@ -41,7 +41,7 @@ def test_ignition_test_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="HARDWOOD",
             material="Wood, Hardwoods (oak, maple) (3/4 in)",
             conductivity=0.16,
@@ -53,7 +53,7 @@ def test_ignition_test_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=5,
@@ -68,7 +68,7 @@ def test_ignition_test_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=0,
@@ -80,7 +80,7 @@ def test_ignition_test_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ F2",
             comp_id="Comp 1",
             location=[2.5, 3.5, 1],
@@ -90,7 +90,7 @@ def test_ignition_test_simulation(tmp_path):
             temperature_depth=0.0095,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ F3",
             comp_id="Comp 1",
             location=[2.5, 4.5, 1],
@@ -103,7 +103,7 @@ def test_ignition_test_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Initial Fire",
             comp_id="Comp 1",
             fire_id="Initial Fire_Fire",
@@ -141,7 +141,7 @@ def test_ignition_test_simulation(tmp_path):
                 [620, 0, 0, 0.3, 0.008021683, 0.02, 0, 0, 0],
             ],
         ),
-        Fires(
+        Fire(
             id="Second Fire",
             comp_id="Comp 1",
             fire_id="Second Fire_Fire",
@@ -161,7 +161,7 @@ def test_ignition_test_simulation(tmp_path):
                 [100, 2, 0, 0.09, 0.004747221, 0.01, 0, 0, 0],
             ],
         ),
-        Fires(
+        Fire(
             id="Third Fire",
             comp_id="Comp 1",
             fire_id="Third Fire_Fire",

--- a/tests/verification_tests/test_fires.py
+++ b/tests/verification_tests/test_fires.py
@@ -21,7 +21,7 @@ from .verification import (
 
 pytestmark = [pytest.mark.slow, pytest.mark.local]
 
-verification_data_dir = get_verification_data_dir(Path(__file__).parent, "Fire")
+verification_data_dir = get_verification_data_dir(Path(__file__).parent, "Fires")
 
 
 def test_ignition_test_simulation(tmp_path):

--- a/tests/verification_tests/test_mass_balance.py
+++ b/tests/verification_tests/test_mass_balance.py
@@ -5,12 +5,12 @@ from pathlib import Path
 import pytest
 
 from pycfast import (
-    CeilingFloorVents,
+    CeilingFloorVent,
     CFASTModel,
-    Compartments,
-    Fires,
+    Compartment,
+    Fire,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -40,7 +40,7 @@ def test_species_mass_1_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=6,
@@ -55,7 +55,7 @@ def test_species_mass_1_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="simple burner",
             comp_id="Comp 1",
             fire_id="simple burner_Fire",
@@ -117,7 +117,7 @@ def test_species_mass_2_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=8,
@@ -129,7 +129,7 @@ def test_species_mass_2_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2",
             depth=3,
             height=8,
@@ -144,7 +144,7 @@ def test_species_mass_2_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "Comp 2"],
             bottom=0,
@@ -156,7 +156,7 @@ def test_species_mass_2_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="simple burner",
             comp_id="Comp 1",
             fire_id="simple burner_Fire",
@@ -218,7 +218,7 @@ def test_species_mass_3_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=4,
@@ -230,7 +230,7 @@ def test_species_mass_3_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2",
             depth=5,
             height=2,
@@ -245,7 +245,7 @@ def test_species_mass_3_simulation(tmp_path):
     ]
 
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_1",
             comps_ids=["Comp 2", "Comp 1"],
             area=4,
@@ -256,7 +256,7 @@ def test_species_mass_3_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="simple burner",
             comp_id="Comp 1",
             fire_id="simple burner_Fire",
@@ -319,7 +319,7 @@ def test_species_mass_4_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=4,
             height=4,
@@ -332,7 +332,7 @@ def test_species_mass_4_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2",
             depth=4,
             height=4,
@@ -345,7 +345,7 @@ def test_species_mass_4_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3",
             depth=4,
             height=4,
@@ -358,7 +358,7 @@ def test_species_mass_4_simulation(tmp_path):
             origin_y=0,
             origin_z=4,
         ),
-        Compartments(
+        Compartment(
             id="Comp 4",
             depth=4,
             height=4,
@@ -374,7 +374,7 @@ def test_species_mass_4_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "Comp 2"],
             bottom=0,
@@ -386,7 +386,7 @@ def test_species_mass_4_simulation(tmp_path):
             time=[1000, 1001],
             fraction=[0, 1],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Comp 3", "Comp 4"],
             bottom=0,
@@ -401,7 +401,7 @@ def test_species_mass_4_simulation(tmp_path):
     ]
 
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_1",
             comps_ids=["Comp 3", "Comp 2"],
             area=16,
@@ -412,7 +412,7 @@ def test_species_mass_4_simulation(tmp_path):
             time=[2500, 2501],
             fraction=[0, 1],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_2",
             comps_ids=["OUTSIDE", "Comp 4"],
             area=16,
@@ -426,7 +426,7 @@ def test_species_mass_4_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="simple burner",
             comp_id="Comp 1",
             fire_id="simple burner_Fire",

--- a/tests/verification_tests/test_model.py
+++ b/tests/verification_tests/test_model.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import pytest
 
 from pycfast import (
-    CeilingFloorVents,
+    CeilingFloorVent,
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
-    SurfaceConnections,
-    WallVents,
+    SurfaceConnection,
+    WallVent,
 )
 
 pytestmark = [pytest.mark.slow, pytest.mark.local]
@@ -35,7 +35,7 @@ def test_run_returns_results(tmp_path):
         max_time_step=10,
     )
     material_properties = [
-        MaterialProperties(
+        Material(
             id="Gypboard",
             material="Gypsum Board",
             conductivity=0.16,
@@ -46,7 +46,7 @@ def test_run_returns_results(tmp_path):
         )
     ]
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=10.0,
             height=10.0,
@@ -61,7 +61,7 @@ def test_run_returns_results(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2",
             depth=10.0,
             height=10.0,
@@ -78,7 +78,7 @@ def test_run_returns_results(tmp_path):
         ),
     ]
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=0.02,
@@ -89,7 +89,7 @@ def test_run_returns_results(tmp_path):
         )
     ]
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_1",
             comps_ids=["Comp 2", "Comp 1"],
             area=0.01,
@@ -100,7 +100,7 @@ def test_run_returns_results(tmp_path):
         )
     ]
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="mech",
             comps_ids=["OUTSIDE", "Comp 1"],
             area=[1.2, 10],
@@ -114,7 +114,7 @@ def test_run_returns_results(tmp_path):
         )
     ]
     fires = [
-        Fires(
+        Fire(
             id="Propane",
             comp_id="Comp 1",
             fire_id="Propane_Fire",
@@ -133,7 +133,7 @@ def test_run_returns_results(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Target_1",
             comp_id="Comp 1",
             location=[0.5, 0.5, 0],
@@ -147,7 +147,7 @@ def test_run_returns_results(tmp_path):
     ]
 
     surface_connections = [
-        SurfaceConnections.ceiling_floor_connection(
+        SurfaceConnection.ceiling_floor_connection(
             comp_id="Comp 1",
             comp_ids="Comp 2",
         )

--- a/tests/verification_tests/test_parser_verification.py
+++ b/tests/verification_tests/test_parser_verification.py
@@ -110,7 +110,7 @@ def test_parser_verification_file_discovery():
     expected_dirs = {
         "DOE_Guidance_Report",
         "Energy_Balance",
-        "Fires",
+        "Fire",
         "Mass_Balance",
         "NRC_Users_Guide" + os.sep + "A_Cabinet_Fire_in_MCR",
         "NRC_Users_Guide" + os.sep + "B_Cabinet_Fire_in_Switchgear",

--- a/tests/verification_tests/test_parser_verification.py
+++ b/tests/verification_tests/test_parser_verification.py
@@ -110,7 +110,7 @@ def test_parser_verification_file_discovery():
     expected_dirs = {
         "DOE_Guidance_Report",
         "Energy_Balance",
-        "Fire",
+        "Fires",
         "Mass_Balance",
         "NRC_Users_Guide" + os.sep + "A_Cabinet_Fire_in_MCR",
         "NRC_Users_Guide" + os.sep + "B_Cabinet_Fire_in_Switchgear",

--- a/tests/verification_tests/test_radiation.py
+++ b/tests/verification_tests/test_radiation.py
@@ -5,12 +5,12 @@ from pathlib import Path
 import pytest
 
 from pycfast import (
-    CeilingFloorVents,
+    CeilingFloorVent,
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
+    Compartment,
+    Device,
+    Fire,
+    Material,
     SimulationEnvironment,
 )
 
@@ -41,7 +41,7 @@ def test_radiation_1_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="STEELSHT",
             material="Steel, Plain Carbon (1/16 in)",
             conductivity=48,
@@ -53,7 +53,7 @@ def test_radiation_1_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=99,
             height=99,
@@ -68,7 +68,7 @@ def test_radiation_1_simulation(tmp_path):
     ]
 
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_1",
             comps_ids=["OUTSIDE", "Comp 1"],
             area=20,
@@ -79,7 +79,7 @@ def test_radiation_1_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Comp 1",
             location=[9.5, 7.5, 0],
@@ -92,7 +92,7 @@ def test_radiation_1_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="New Fire",
             comp_id="Comp 1",
             fire_id="New Fire_Fire",
@@ -157,7 +157,7 @@ def test_radiation_2_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="STEELROD",
             material="Steel Rod, 2.5 cm diameter",
             conductivity=54,
@@ -166,7 +166,7 @@ def test_radiation_2_simulation(tmp_path):
             thickness=0.025,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="STEELTHCK",
             material="Thick Steel (1 in)",
             conductivity=54,
@@ -175,7 +175,7 @@ def test_radiation_2_simulation(tmp_path):
             thickness=0.025,
             emissivity=0.9,
         ),
-        MaterialProperties(
+        Material(
             id="STEELSHT",
             material="Thin Steel (1/16 in)",
             conductivity=54,
@@ -187,7 +187,7 @@ def test_radiation_2_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=5,
@@ -202,7 +202,7 @@ def test_radiation_2_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Comp 1",
             location=[2.5, 2.5, 0.01],
@@ -212,7 +212,7 @@ def test_radiation_2_simulation(tmp_path):
             temperature_depth=0.0125,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Comp 1",
             location=[1.5, 2.5, 0.01],
@@ -222,7 +222,7 @@ def test_radiation_2_simulation(tmp_path):
             temperature_depth=0.0125,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3",
             comp_id="Comp 1",
             location=[3.5, 2.5, 0.01],
@@ -283,7 +283,7 @@ def test_radiation_3_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="CONCRETE",
             material="CONCRETE",
             conductivity=1.75,
@@ -295,7 +295,7 @@ def test_radiation_3_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=2,
             height=4,
@@ -314,7 +314,7 @@ def test_radiation_3_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1top",
             comp_id="Comp 1",
             location=[0.0909, 1, 4],
@@ -324,7 +324,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2top",
             comp_id="Comp 1",
             location=[0.2727, 1, 4],
@@ -334,7 +334,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3top",
             comp_id="Comp 1",
             location=[0.4545, 1, 4],
@@ -344,7 +344,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4top",
             comp_id="Comp 1",
             location=[0.6363, 1, 4],
@@ -354,7 +354,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5top",
             comp_id="Comp 1",
             location=[0.8181, 1, 4],
@@ -364,7 +364,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 6top",
             comp_id="Comp 1",
             location=[1, 1, 4],
@@ -374,7 +374,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 7top",
             comp_id="Comp 1",
             location=[1.1817, 1, 4],
@@ -384,7 +384,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 8top",
             comp_id="Comp 1",
             location=[1.3635, 1, 4],
@@ -394,7 +394,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 9top",
             comp_id="Comp 1",
             location=[1.5453, 1, 4],
@@ -404,7 +404,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 10top",
             comp_id="Comp 1",
             location=[1.7271, 1, 4],
@@ -414,7 +414,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 11top",
             comp_id="Comp 1",
             location=[1.9089, 1, 4],
@@ -424,7 +424,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1side",
             comp_id="Comp 1",
             location=[2, 1, 0.125],
@@ -434,7 +434,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2side",
             comp_id="Comp 1",
             location=[2, 1, 0.375],
@@ -444,7 +444,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3side",
             comp_id="Comp 1",
             location=[2, 1, 0.625],
@@ -454,7 +454,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4side",
             comp_id="Comp 1",
             location=[2, 1, 0.875],
@@ -464,7 +464,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5side",
             comp_id="Comp 1",
             location=[2, 1, 1.125],
@@ -474,7 +474,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 6side",
             comp_id="Comp 1",
             location=[2, 1, 1.375],
@@ -484,7 +484,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 7side",
             comp_id="Comp 1",
             location=[2, 1, 1.625],
@@ -494,7 +494,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 8side",
             comp_id="Comp 1",
             location=[2, 1, 1.875],
@@ -504,7 +504,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 9side",
             comp_id="Comp 1",
             location=[2, 1, 2.125],
@@ -514,7 +514,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 10side",
             comp_id="Comp 1",
             location=[2, 1, 2.375],
@@ -524,7 +524,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 11side",
             comp_id="Comp 1",
             location=[2, 1, 2.625],
@@ -534,7 +534,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 12side",
             comp_id="Comp 1",
             location=[2, 1, 2.875],
@@ -544,7 +544,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 13side",
             comp_id="Comp 1",
             location=[2, 1, 3.125],
@@ -554,7 +554,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 14side",
             comp_id="Comp 1",
             location=[2, 1, 3.375],
@@ -564,7 +564,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 15side",
             comp_id="Comp 1",
             location=[2, 1, 3.625],
@@ -574,7 +574,7 @@ def test_radiation_3_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 16side",
             comp_id="Comp 1",
             location=[2, 1, 3.875],
@@ -635,7 +635,7 @@ def test_radiation_4_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="CONCRETE",
             material="CONCRETE",
             conductivity=1.75,
@@ -647,7 +647,7 @@ def test_radiation_4_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=2,
             height=4,
@@ -666,7 +666,7 @@ def test_radiation_4_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1top",
             comp_id="Comp 1",
             location=[0.0909, 1, 4],
@@ -676,7 +676,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2top",
             comp_id="Comp 1",
             location=[0.2727, 1, 4],
@@ -686,7 +686,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3top",
             comp_id="Comp 1",
             location=[0.4545, 1, 4],
@@ -696,7 +696,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4top",
             comp_id="Comp 1",
             location=[0.6363, 1, 4],
@@ -706,7 +706,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5top",
             comp_id="Comp 1",
             location=[0.8181, 1, 4],
@@ -716,7 +716,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 6top",
             comp_id="Comp 1",
             location=[1, 1, 4],
@@ -726,7 +726,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 7top",
             comp_id="Comp 1",
             location=[1.1817, 1, 4],
@@ -736,7 +736,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 8top",
             comp_id="Comp 1",
             location=[1.3635, 1, 4],
@@ -746,7 +746,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 9top",
             comp_id="Comp 1",
             location=[1.5453, 1, 4],
@@ -756,7 +756,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 10top",
             comp_id="Comp 1",
             location=[1.7271, 1, 4],
@@ -766,7 +766,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 11top",
             comp_id="Comp 1",
             location=[1.9089, 1, 4],
@@ -776,7 +776,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1side",
             comp_id="Comp 1",
             location=[2, 1, 0.125],
@@ -786,7 +786,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2side",
             comp_id="Comp 1",
             location=[2, 1, 0.375],
@@ -796,7 +796,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3side",
             comp_id="Comp 1",
             location=[2, 1, 0.625],
@@ -806,7 +806,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4side",
             comp_id="Comp 1",
             location=[2, 1, 0.875],
@@ -816,7 +816,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5side",
             comp_id="Comp 1",
             location=[2, 1, 1.125],
@@ -826,7 +826,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 6side",
             comp_id="Comp 1",
             location=[2, 1, 1.375],
@@ -836,7 +836,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 7side",
             comp_id="Comp 1",
             location=[2, 1, 1.625],
@@ -846,7 +846,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 8side",
             comp_id="Comp 1",
             location=[2, 1, 1.875],
@@ -856,7 +856,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 9side",
             comp_id="Comp 1",
             location=[2, 1, 2.125],
@@ -866,7 +866,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 10side",
             comp_id="Comp 1",
             location=[2, 1, 2.375],
@@ -876,7 +876,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 11side",
             comp_id="Comp 1",
             location=[2, 1, 2.625],
@@ -886,7 +886,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 12side",
             comp_id="Comp 1",
             location=[2, 1, 2.875],
@@ -896,7 +896,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 13side",
             comp_id="Comp 1",
             location=[2, 1, 3.125],
@@ -906,7 +906,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 14side",
             comp_id="Comp 1",
             location=[2, 1, 3.375],
@@ -916,7 +916,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 15side",
             comp_id="Comp 1",
             location=[2, 1, 3.625],
@@ -926,7 +926,7 @@ def test_radiation_4_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 16side",
             comp_id="Comp 1",
             location=[2, 1, 3.875],
@@ -988,7 +988,7 @@ def test_radiation_5_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="CONCRETE",
             material="CONCRETE",
             conductivity=1.75,
@@ -1000,7 +1000,7 @@ def test_radiation_5_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=2,
             height=4,
@@ -1019,7 +1019,7 @@ def test_radiation_5_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1top",
             comp_id="Comp 1",
             location=[0.0909, 1, 4],
@@ -1029,7 +1029,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2top",
             comp_id="Comp 1",
             location=[0.2727, 1, 4],
@@ -1039,7 +1039,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3top",
             comp_id="Comp 1",
             location=[0.4545, 1, 4],
@@ -1049,7 +1049,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4top",
             comp_id="Comp 1",
             location=[0.6363, 1, 4],
@@ -1059,7 +1059,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5top",
             comp_id="Comp 1",
             location=[0.8181, 1, 4],
@@ -1069,7 +1069,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 6top",
             comp_id="Comp 1",
             location=[1, 1, 4],
@@ -1079,7 +1079,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 7top",
             comp_id="Comp 1",
             location=[1.1817, 1, 4],
@@ -1089,7 +1089,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 8top",
             comp_id="Comp 1",
             location=[1.3635, 1, 4],
@@ -1099,7 +1099,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 9top",
             comp_id="Comp 1",
             location=[1.5453, 1, 4],
@@ -1109,7 +1109,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 10top",
             comp_id="Comp 1",
             location=[1.7271, 1, 4],
@@ -1119,7 +1119,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 11top",
             comp_id="Comp 1",
             location=[1.9089, 1, 4],
@@ -1129,7 +1129,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1side",
             comp_id="Comp 1",
             location=[2, 1, 0.125],
@@ -1139,7 +1139,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2side",
             comp_id="Comp 1",
             location=[2, 1, 0.375],
@@ -1149,7 +1149,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3side",
             comp_id="Comp 1",
             location=[2, 1, 0.625],
@@ -1159,7 +1159,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4side",
             comp_id="Comp 1",
             location=[2, 1, 0.875],
@@ -1169,7 +1169,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5side",
             comp_id="Comp 1",
             location=[2, 1, 1.125],
@@ -1179,7 +1179,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 6side",
             comp_id="Comp 1",
             location=[2, 1, 1.375],
@@ -1189,7 +1189,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 7side",
             comp_id="Comp 1",
             location=[2, 1, 1.625],
@@ -1199,7 +1199,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 8side",
             comp_id="Comp 1",
             location=[2, 1, 1.875],
@@ -1209,7 +1209,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 9side",
             comp_id="Comp 1",
             location=[2, 1, 2.125],
@@ -1219,7 +1219,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 10side",
             comp_id="Comp 1",
             location=[2, 1, 2.375],
@@ -1229,7 +1229,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 11side",
             comp_id="Comp 1",
             location=[2, 1, 2.625],
@@ -1239,7 +1239,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 12side",
             comp_id="Comp 1",
             location=[2, 1, 2.875],
@@ -1249,7 +1249,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 13side",
             comp_id="Comp 1",
             location=[2, 1, 3.125],
@@ -1259,7 +1259,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 14side",
             comp_id="Comp 1",
             location=[2, 1, 3.375],
@@ -1269,7 +1269,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 15side",
             comp_id="Comp 1",
             location=[2, 1, 3.625],
@@ -1279,7 +1279,7 @@ def test_radiation_5_simulation(tmp_path):
             temperature_depth=0.075,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 16side",
             comp_id="Comp 1",
             location=[2, 1, 3.875],

--- a/tests/verification_tests/test_species.py
+++ b/tests/verification_tests/test_species.py
@@ -6,11 +6,11 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
-    MechanicalVents,
+    Compartment,
+    Device,
+    Fire,
+    Material,
+    MechanicalVent,
     SimulationEnvironment,
 )
 
@@ -43,7 +43,7 @@ def test_species_test_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Room_1",
             depth=5,
             height=5,
@@ -59,7 +59,7 @@ def test_species_test_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Methane_Fire",
             comp_id="Room_1",
             fire_id="Species_Fire",
@@ -125,7 +125,7 @@ def test_methane_flame_simple_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Room_1",
             depth=5,
             height=5,
@@ -141,7 +141,7 @@ def test_methane_flame_simple_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Methane_Fire",
             comp_id="Room_1",
             fire_id="Methane_Fire",
@@ -205,7 +205,7 @@ def test_gas_tenability_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="Steel",
             material="Steel",
             conductivity=54,
@@ -217,7 +217,7 @@ def test_gas_tenability_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=5,
@@ -236,7 +236,7 @@ def test_gas_tenability_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="CO",
             comp_id="Comp 1",
             fire_id="CO_Fire",
@@ -258,7 +258,7 @@ def test_gas_tenability_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Comp 1",
             location=[2.5, 2.5, 4.9],
@@ -314,7 +314,7 @@ def test_heat_tenability_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="Steel",
             material="Steel",
             conductivity=54,
@@ -326,7 +326,7 @@ def test_heat_tenability_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=5,
@@ -342,7 +342,7 @@ def test_heat_tenability_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Comp 1",
             location=[2.5, 2.5, 2.5],
@@ -398,7 +398,7 @@ def test_trace_species_1_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Room_1",
             depth=5,
             height=5,
@@ -414,7 +414,7 @@ def test_trace_species_1_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Methane_Fire",
             comp_id="Room_1",
             fire_id="Methane_Fire",
@@ -479,7 +479,7 @@ def test_trace_species_2_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Room_1",
             depth=10,
             height=2,
@@ -492,7 +492,7 @@ def test_trace_species_2_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Room_2",
             depth=10,
             height=2,
@@ -508,7 +508,7 @@ def test_trace_species_2_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["Room_1", "Room_2"],
             area=[1, 1],
@@ -521,7 +521,7 @@ def test_trace_species_2_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["Room_2", "Room_1"],
             area=[1, 1],
@@ -537,7 +537,7 @@ def test_trace_species_2_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Methane_Fire",
             comp_id="Room_1",
             fire_id="Methane_Fire",
@@ -602,7 +602,7 @@ def test_trace_species_3_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Room_1",
             depth=10,
             height=2,
@@ -615,7 +615,7 @@ def test_trace_species_3_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Room_2",
             depth=10,
             height=2,
@@ -631,7 +631,7 @@ def test_trace_species_3_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["Room_1", "Room_2"],
             area=[1, 1],
@@ -644,7 +644,7 @@ def test_trace_species_3_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=100,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["Room_2", "Room_1"],
             area=[1, 1],
@@ -660,7 +660,7 @@ def test_trace_species_3_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="Methane_Fire",
             comp_id="Room_1",
             fire_id="Methane_Fire",

--- a/tests/verification_tests/test_sprinkler.py
+++ b/tests/verification_tests/test_sprinkler.py
@@ -6,9 +6,9 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
+    Compartment,
+    Device,
+    Fire,
     SimulationEnvironment,
 )
 
@@ -40,7 +40,7 @@ def test_sprinkler_1_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=4,
             height=4,
@@ -60,7 +60,7 @@ def test_sprinkler_1_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="New Fire",
             comp_id="Comp 1",
             fire_id="New Fire_Fire",
@@ -77,7 +77,7 @@ def test_sprinkler_1_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_sprinkler(
+        Device.create_sprinkler(
             id="Sprinkler_1",
             comp_id="Comp 1",
             location=[2, 2, 3.96],

--- a/tests/verification_tests/test_target.py
+++ b/tests/verification_tests/test_target.py
@@ -6,10 +6,10 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    Devices,
-    Fires,
-    MaterialProperties,
+    Compartment,
+    Device,
+    Fire,
+    Material,
     SimulationEnvironment,
 )
 
@@ -43,7 +43,7 @@ def test_target_1_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="ConcreteBE2",
             material="Concrete ICFMP BE2",
             conductivity=2,
@@ -52,7 +52,7 @@ def test_target_1_simulation(tmp_path):
             thickness=0.15,
             emissivity=0.95,
         ),
-        MaterialProperties(
+        Material(
             id="TC",
             material="Thermocouple (small steel target for plume temp)",
             conductivity=54,
@@ -64,7 +64,7 @@ def test_target_1_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Compartment 1",
             depth=10,
             height=10,
@@ -82,7 +82,7 @@ def test_target_1_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Compartment 1",
             location=[5, 5, 5],
@@ -145,7 +145,7 @@ def test_target_2_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="Concrete",
             material="Concrete",
             conductivity=1.6,
@@ -157,7 +157,7 @@ def test_target_2_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp_1",
             depth=6,
             height=8,
@@ -175,7 +175,7 @@ def test_target_2_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="MCC 702 kW",
             comp_id="Comp_1",
             fire_id="MCC 702 kW_Fire",
@@ -195,7 +195,7 @@ def test_target_2_simulation(tmp_path):
     ]
 
     devices = [
-        Devices.create_target(
+        Device.create_target(
             id="Targ 1",
             comp_id="Comp_1",
             location=[3, 3, 8],
@@ -205,7 +205,7 @@ def test_target_2_simulation(tmp_path):
             temperature_depth=0.3,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 2",
             comp_id="Comp_1",
             location=[3, 3, 6],
@@ -215,7 +215,7 @@ def test_target_2_simulation(tmp_path):
             temperature_depth=0.3,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 3",
             comp_id="Comp_1",
             location=[3, 3, 5],
@@ -225,7 +225,7 @@ def test_target_2_simulation(tmp_path):
             temperature_depth=0.3,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 4",
             comp_id="Comp_1",
             location=[3, 3, 4.5],
@@ -235,7 +235,7 @@ def test_target_2_simulation(tmp_path):
             temperature_depth=0.3,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 5",
             comp_id="Comp_1",
             location=[3, 3, 4.4],
@@ -245,7 +245,7 @@ def test_target_2_simulation(tmp_path):
             temperature_depth=0.3,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 6",
             comp_id="Comp_1",
             location=[3, 3, 4.3],
@@ -255,7 +255,7 @@ def test_target_2_simulation(tmp_path):
             temperature_depth=0.3,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 7",
             comp_id="Comp_1",
             location=[3, 3, 4.2],
@@ -265,7 +265,7 @@ def test_target_2_simulation(tmp_path):
             temperature_depth=0.3,
             depth_units="M",
         ),
-        Devices.create_target(
+        Device.create_target(
             id="Targ 8",
             comp_id="Comp_1",
             location=[3, 3, 4.1],

--- a/tests/verification_tests/test_thermal_equilibrium.py
+++ b/tests/verification_tests/test_thermal_equilibrium.py
@@ -6,10 +6,10 @@ import pytest
 
 from pycfast import (
     CFASTModel,
-    Compartments,
-    MaterialProperties,
+    Compartment,
+    Material,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -41,7 +41,7 @@ def test_basic_tempequilib_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="GYPSUM",
             material="Gypsum Board (5/8 in)",
             conductivity=0.16,
@@ -53,7 +53,7 @@ def test_basic_tempequilib_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Compartment 1",
             depth=5,
             height=5,
@@ -111,7 +111,7 @@ def test_basic_tempequilib_window_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="GYPSUM",
             material="Gypsum Board (5/8 in)",
             conductivity=0.16,
@@ -123,7 +123,7 @@ def test_basic_tempequilib_window_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Compartment 1",
             depth=5,
             height=5,
@@ -140,7 +140,7 @@ def test_basic_tempequilib_window_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Compartment 1", "OUTSIDE"],
             bottom=1.5,
@@ -193,7 +193,7 @@ def test_basic_tempequilib_window_elevation_simulation(tmp_path):
     )
 
     material_properties = [
-        MaterialProperties(
+        Material(
             id="GYPSUM",
             material="Gypsum Board (5/8 in)",
             conductivity=0.16,
@@ -205,7 +205,7 @@ def test_basic_tempequilib_window_elevation_simulation(tmp_path):
     ]
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Compartment 1",
             depth=5,
             height=5,
@@ -222,7 +222,7 @@ def test_basic_tempequilib_window_elevation_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Compartment 1", "OUTSIDE"],
             bottom=2,

--- a/tests/verification_tests/test_ventilation.py
+++ b/tests/verification_tests/test_ventilation.py
@@ -5,13 +5,13 @@ from pathlib import Path
 import pytest
 
 from pycfast import (
-    CeilingFloorVents,
+    CeilingFloorVent,
     CFASTModel,
-    Compartments,
-    Fires,
-    MechanicalVents,
+    Compartment,
+    Fire,
+    MechanicalVent,
     SimulationEnvironment,
-    WallVents,
+    WallVent,
 )
 
 from .verification import (
@@ -41,7 +41,7 @@ def test_ventilation_1_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=3,
@@ -56,7 +56,7 @@ def test_ventilation_1_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=1.495,
@@ -68,7 +68,7 @@ def test_ventilation_1_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Comp 1"],
             area=[1, 1],
@@ -124,7 +124,7 @@ def test_leakage_1_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=1,
             height=1,
@@ -141,7 +141,7 @@ def test_leakage_1_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Comp 1"],
             area=[0.1, 0.1],
@@ -199,7 +199,7 @@ def test_leakage_2_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=1,
             height=1,
@@ -216,7 +216,7 @@ def test_leakage_2_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Comp 1"],
             area=[0.1, 0.1],
@@ -273,7 +273,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
         extra_custom="&DIAG UPPER_LAYER_THICKNESS = 1 VERIFICATION_TIME_STEP = 0.5/",
     )
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=4,
             height=3,
@@ -285,7 +285,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2",
             depth=4,
             height=5,
@@ -297,7 +297,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             origin_y=0,
             origin_z=3,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3",
             depth=4,
             height=6,
@@ -312,7 +312,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="HVENT 1",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=2.5,
@@ -324,7 +324,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        WallVents(
+        WallVent(
             id="HVENT 2",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=0,
@@ -336,7 +336,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        WallVents(
+        WallVent(
             id="HVENT 3",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=0,
@@ -348,7 +348,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        WallVents(
+        WallVent(
             id="HVENT 4",
             comps_ids=["Comp 1", "Comp 3"],
             bottom=1,
@@ -360,7 +360,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        WallVents(
+        WallVent(
             id="HVENT 5",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=0.5,
@@ -372,7 +372,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        WallVents(
+        WallVent(
             id="HVENT 6",
             comps_ids=["Comp 2", "Comp 3"],
             bottom=0,
@@ -384,7 +384,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        WallVents(
+        WallVent(
             id="HVENT 7",
             comps_ids=["Comp 2", "OUTSIDE"],
             bottom=4,
@@ -396,7 +396,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        WallVents(
+        WallVent(
             id="HVENT 8",
             comps_ids=["Comp 2", "OUTSIDE"],
             bottom=0.5,
@@ -411,7 +411,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
     ]
 
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="VVENT 1",
             comps_ids=["Comp 2", "Comp 1"],
             area=1,
@@ -422,7 +422,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="VVENT 2",
             comps_ids=["Comp 1", "OUTSIDE"],
             area=1,
@@ -433,7 +433,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             time=[0, 0.5, 1],
             fraction=[0, 0.5, 1],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="VVENT 3",
             comps_ids=["OUTSIDE", "Comp 3"],
             area=1,
@@ -447,7 +447,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MVENT 1",
             comps_ids=["Comp 1", "OUTSIDE"],
             area=[1, 1],
@@ -460,7 +460,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MVENT 2",
             comps_ids=["Comp 1", "Comp 2"],
             area=[1, 1],
@@ -474,7 +474,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MVENT 3",
             comps_ids=["Comp 1", "Comp 3"],
             area=[0.25, 0.25],
@@ -487,7 +487,7 @@ def test_surface_opened_fraction_1_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MVENT 4",
             comps_ids=["Comp 2", "Comp 3"],
             area=[0.25, 0.25],
@@ -544,7 +544,7 @@ def test_ventilation_2_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=4,
             height=4,
@@ -557,7 +557,7 @@ def test_ventilation_2_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2",
             depth=4,
             height=4,
@@ -570,7 +570,7 @@ def test_ventilation_2_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3",
             depth=4,
             height=4,
@@ -583,7 +583,7 @@ def test_ventilation_2_simulation(tmp_path):
             origin_y=0,
             origin_z=4,
         ),
-        Compartments(
+        Compartment(
             id="Comp 4",
             depth=4,
             height=4,
@@ -599,7 +599,7 @@ def test_ventilation_2_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "Comp 2"],
             bottom=1.5,
@@ -608,7 +608,7 @@ def test_ventilation_2_simulation(tmp_path):
             face="RIGHT",
             offset=1.5,
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Comp 3", "Comp 4"],
             bottom=1.5,
@@ -620,7 +620,7 @@ def test_ventilation_2_simulation(tmp_path):
     ]
 
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_1",
             comps_ids=["Comp 3", "Comp 2"],
             area=1,
@@ -631,7 +631,7 @@ def test_ventilation_2_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Comp 1"],
             area=[1, 1],
@@ -642,7 +642,7 @@ def test_ventilation_2_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["Comp 4", "OUTSIDE"],
             area=[1, 1],
@@ -697,7 +697,7 @@ def test_ventilation_3_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=4,
             height=4,
@@ -710,7 +710,7 @@ def test_ventilation_3_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2",
             depth=4,
             height=4,
@@ -723,7 +723,7 @@ def test_ventilation_3_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3",
             depth=4,
             height=4,
@@ -736,7 +736,7 @@ def test_ventilation_3_simulation(tmp_path):
             origin_y=0,
             origin_z=4,
         ),
-        Compartments(
+        Compartment(
             id="Comp 4",
             depth=4,
             height=4,
@@ -752,7 +752,7 @@ def test_ventilation_3_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "Comp 2"],
             bottom=0,
@@ -764,7 +764,7 @@ def test_ventilation_3_simulation(tmp_path):
             time=[200, 201],
             fraction=[0, 1],
         ),
-        WallVents(
+        WallVent(
             id="WallVent_2",
             comps_ids=["Comp 3", "Comp 4"],
             bottom=0,
@@ -779,7 +779,7 @@ def test_ventilation_3_simulation(tmp_path):
     ]
 
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_1",
             comps_ids=["Comp 3", "Comp 2"],
             area=3,
@@ -790,7 +790,7 @@ def test_ventilation_3_simulation(tmp_path):
             time=[500, 501],
             fraction=[0, 1],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_2",
             comps_ids=["OUTSIDE", "Comp 4"],
             area=4,
@@ -804,7 +804,7 @@ def test_ventilation_3_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Comp 1"],
             area=[1, 1],
@@ -863,7 +863,7 @@ def test_ventilation_4_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1",
             depth=5,
             height=5,
@@ -878,7 +878,7 @@ def test_ventilation_4_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 1", "OUTSIDE"],
             bottom=0,
@@ -890,7 +890,7 @@ def test_ventilation_4_simulation(tmp_path):
     ]
 
     fires = [
-        Fires(
+        Fire(
             id="simple",
             comp_id="Comp 1",
             fire_id="simple_Fire",
@@ -953,7 +953,7 @@ def test_vvent_tests_simulation(tmp_path):
     )
 
     compartments = [
-        Compartments(
+        Compartment(
             id="Comp 1 Up",
             depth=5,
             height=5,
@@ -965,7 +965,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2 Up",
             depth=5,
             height=5,
@@ -977,7 +977,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=5,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3 Up",
             depth=5,
             height=5,
@@ -989,7 +989,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=10,
         ),
-        Compartments(
+        Compartment(
             id="Comp 1 Down",
             depth=5,
             height=5,
@@ -1001,7 +1001,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2 Down",
             depth=5,
             height=5,
@@ -1013,7 +1013,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=5,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3 Down",
             depth=5,
             height=5,
@@ -1025,7 +1025,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=10,
         ),
-        Compartments(
+        Compartment(
             id="Comp 1 Both",
             depth=5,
             height=5,
@@ -1037,7 +1037,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2 Both",
             depth=5,
             height=5,
@@ -1049,7 +1049,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=5,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3 Both",
             depth=5,
             height=5,
@@ -1061,7 +1061,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=10,
         ),
-        Compartments(
+        Compartment(
             id="Comp 1 All Vents",
             depth=5,
             height=5,
@@ -1073,7 +1073,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=0,
         ),
-        Compartments(
+        Compartment(
             id="Comp 2 All Vents",
             depth=5,
             height=5,
@@ -1085,7 +1085,7 @@ def test_vvent_tests_simulation(tmp_path):
             origin_y=0,
             origin_z=5,
         ),
-        Compartments(
+        Compartment(
             id="Comp 3 All Vents",
             depth=5,
             height=5,
@@ -1100,7 +1100,7 @@ def test_vvent_tests_simulation(tmp_path):
     ]
 
     wall_vents = [
-        WallVents(
+        WallVent(
             id="WallVent_1",
             comps_ids=["Comp 3 All Vents", "OUTSIDE"],
             bottom=2.25,
@@ -1115,7 +1115,7 @@ def test_vvent_tests_simulation(tmp_path):
     ]
 
     ceiling_floor_vents = [
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_1",
             comps_ids=["OUTSIDE", "Comp 3 Up"],
             area=0.25,
@@ -1123,7 +1123,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_2",
             comps_ids=["Comp 3 Up", "Comp 2 Up"],
             area=0.25,
@@ -1131,7 +1131,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_3",
             comps_ids=["Comp 2 Up", "Comp 1 Up"],
             area=0.25,
@@ -1139,7 +1139,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_4",
             comps_ids=["Comp 3 Down", "Comp 2 Down"],
             area=0.25,
@@ -1147,7 +1147,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_5",
             comps_ids=["Comp 2 Down", "Comp 1 Down"],
             area=0.25,
@@ -1155,7 +1155,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_6",
             comps_ids=["Comp 1 Down", "OUTSIDE"],
             area=0.25,
@@ -1163,7 +1163,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_7",
             comps_ids=["OUTSIDE", "Comp 3 Both"],
             area=0.25,
@@ -1171,7 +1171,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_8",
             comps_ids=["Comp 3 Both", "Comp 2 Both"],
             area=0.25,
@@ -1179,7 +1179,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_9",
             comps_ids=["Comp 2 Both", "Comp 1 Both"],
             area=0.25,
@@ -1187,7 +1187,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_10",
             comps_ids=["Comp 1 Both", "OUTSIDE"],
             area=0.25,
@@ -1195,7 +1195,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_11",
             comps_ids=["Comp 3 All Vents", "Comp 2 All Vents"],
             area=0.25,
@@ -1203,7 +1203,7 @@ def test_vvent_tests_simulation(tmp_path):
             shape="ROUND",
             offsets=[2.5, 2.5],
         ),
-        CeilingFloorVents(
+        CeilingFloorVent(
             id="CeilFloorVent_12",
             comps_ids=["Comp 2 All Vents", "Comp 1 All Vents"],
             area=0.25,
@@ -1214,7 +1214,7 @@ def test_vvent_tests_simulation(tmp_path):
     ]
 
     mechanical_vents = [
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_1",
             comps_ids=["OUTSIDE", "Comp 1 Up"],
             area=[0.25, 0.25],
@@ -1224,7 +1224,7 @@ def test_vvent_tests_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_2",
             comps_ids=["OUTSIDE", "Comp 3 Down"],
             area=[0.25, 0.25],
@@ -1234,7 +1234,7 @@ def test_vvent_tests_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_3",
             comps_ids=["OUTSIDE", "Comp 2 Both"],
             area=[0.25, 0.25],
@@ -1244,7 +1244,7 @@ def test_vvent_tests_simulation(tmp_path):
             filter_time=0,
             filter_efficiency=0,
         ),
-        MechanicalVents(
+        MechanicalVent(
             id="MechanicalVent_4",
             comps_ids=["OUTSIDE", "Comp 1 All Vents"],
             area=[0.25, 0.25],


### PR DESCRIPTION
- Compartments → Compartment
- CeilingFloorVents → CeilingFloorVent
- Devices → Device
- Fires → Fire
- MaterialProperties → Material
- MechanicalVents → MechanicalVent
- SurfaceConnections → SurfaceConnection
- WallVents → WallVent

Also add a base class `CFASTComponent` that other classes will inherit from