### PR TITLE
FEAT: Add Visualization component (#129)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from pycfast.mechanical_vent import MechanicalVent
 from pycfast.model import CFASTModel
 from pycfast.simulation_environment import SimulationEnvironment
 from pycfast.surface_connection import SurfaceConnection
+from pycfast.visualization import Visualization
 from pycfast.wall_vent import WallVent
 
 
@@ -77,6 +78,11 @@ def add_doctest_namespace(doctest_namespace: dict) -> dict:
         comp_ids="ROOM2",
         fraction=0.5,
     )
+    visualization = Visualization.slice_2d(
+        plane="X",
+        position=2.5,
+        comp_id="ROOM1",
+    )
     model = CFASTModel(
         simulation_environment=simulation_env,
         compartments=[room1, room2],
@@ -87,6 +93,7 @@ def add_doctest_namespace(doctest_namespace: dict) -> dict:
         fires=[fire1],
         devices=[temp_sensor],
         surface_connections=[surface_conn],
+        visualizations=[visualization],
     )
 
     doctest_namespace["model"] = model
@@ -100,6 +107,7 @@ def add_doctest_namespace(doctest_namespace: dict) -> dict:
     doctest_namespace["Fire"] = Fire
     doctest_namespace["Device"] = Device
     doctest_namespace["SurfaceConnection"] = SurfaceConnection
+    doctest_namespace["Visualization"] = Visualization
     doctest_namespace["np"] = np
     doctest_namespace["pd"] = pd
     doctest_namespace["simulation_env"] = simulation_env

--- a/docs/source/api/components.rst
+++ b/docs/source/api/components.rst
@@ -20,4 +20,5 @@ CFAST models are composed of various components that represent different aspects
    MechanicalVent
    SimulationEnvironment
    SurfaceConnection
+   Visualization
    WallVent

--- a/src/pycfast/__init__.py
+++ b/src/pycfast/__init__.py
@@ -22,6 +22,7 @@ from .mechanical_vent import MechanicalVent
 from .model import CFASTModel
 from .simulation_environment import SimulationEnvironment
 from .surface_connection import SurfaceConnection
+from .visualization import Visualization
 from .wall_vent import WallVent
 
 logging.getLogger("pycfast").addHandler(logging.NullHandler())
@@ -39,6 +40,7 @@ __all__ = [
     "CFASTModel",
     "SimulationEnvironment",
     "SurfaceConnection",
+    "Visualization",
     "WallVent",
 ]
 

--- a/src/pycfast/model.py
+++ b/src/pycfast/model.py
@@ -29,6 +29,7 @@ from .mechanical_vent import MechanicalVent
 from .simulation_environment import SimulationEnvironment
 from .surface_connection import SurfaceConnection
 from .utils import CSV_READ_CONFIGS
+from .visualization import Visualization
 from .wall_vent import WallVent
 
 logger = logging.getLogger("pycfast")
@@ -54,6 +55,7 @@ _COMPONENT_SPECS: dict[str, tuple[type, str, str, tuple[str, ...]]] = {
     "mech_vent":    (MechanicalVent,    "mechanical_vents",    "Mechanical vent",    ("id",)),
     "device":       (Device,            "devices",             "Device",             ("id",)),
     "surface_conn": (SurfaceConnection, "surface_connections", "Surface connection", ()),
+    "visualization": (Visualization,    "visualizations",      "Visualization",      ()),
 }
 # fmt: on
 
@@ -140,6 +142,8 @@ class CFASTModel:
         List of fire definitions
     targets: List[Device]
         List of target/sensor definitions
+    visualizations: List[Visualization]
+        List of Smokeview visualization definitions
     file_name: str
         Name of the CFAST input file to generate
     cfast_exe: str
@@ -182,6 +186,7 @@ class CFASTModel:
         fires: list[Fire] | None = None,
         devices: list[Device] | None = None,
         surface_connections: list[SurfaceConnection] | None = None,
+        visualizations: list[Visualization] | None = None,
         file_name: str = "cfast_input.in",
         cfast_exe: str | None = None,
         extra_arguments: list[str] | None = None,
@@ -195,6 +200,7 @@ class CFASTModel:
         self.fires = fires or []
         self.devices = devices or []
         self.surface_connections = surface_connections or []
+        self.visualizations = visualizations or []
         self.file_name = file_name
         self.cfast_exe = cfast_exe
         self.extra_arguments = extra_arguments or []
@@ -213,6 +219,7 @@ class CFASTModel:
             f"devices={len(self.devices)}",
             f"material_properties={len(self.material_properties)}",
             f"surface_connections={len(self.surface_connections)}",
+            f"visualizations={len(self.visualizations)}",
         ]
 
         return f"CFASTModel(file_name='{self.file_name}', {', '.join(components)})"
@@ -232,6 +239,7 @@ class CFASTModel:
             ("devices", self.devices),
             ("material_properties", self.material_properties),
             ("surface_connections", self.surface_connections),
+            ("visualizations", self.visualizations),
         ]
 
         for component_type, components in component_types:
@@ -729,6 +737,38 @@ class CFASTModel:
         """
         return self._update_component("surface_conn", connection, **kwargs)
 
+    def update_visualization_params(
+        self,
+        visualization: int | None = None,
+        **kwargs: Any,
+    ) -> CFASTModel:
+        """
+        Update visualization parameters and return a new model instance.
+
+        Parameters
+        ----------
+        visualization : int | None, optional
+            Visualization identifier. Can be:
+            - int: Visualization index (0-based)
+            - None: Updates first visualization (index 0)
+        **kwargs : Any
+            Visualization attributes to update. See Visualization class
+            documentation for available parameters.
+
+        Returns
+        -------
+        CFASTModel
+            New model instance with updated visualization parameters
+
+        Examples
+        --------
+        >>> new_model = model.update_visualization_params(
+        ...     visualization=0,
+        ...     position=1.5
+        ... )
+        """
+        return self._update_component("visualization", visualization, **kwargs)
+
     def add(self, component: CFASTComponent) -> CFASTModel:
         """
         Add a component to the model and return a new model instance with it included.
@@ -738,7 +778,7 @@ class CFASTModel:
         component : CFASTComponent
             One of: :class:`Fire`, :class:`Compartment`, :class:`Material`,
             :class:`WallVent`, :class:`CeilingFloorVent`, :class:`MechanicalVent`,
-            :class:`Device`, :class:`SurfaceConnection`.
+            :class:`Device`, :class:`SurfaceConnection`, :class:`Visualization`.
 
         Returns
         -------
@@ -965,6 +1005,11 @@ class CFASTModel:
             for conn in self.surface_connections:
                 lines.append(f"    {conn}")
 
+        if self.visualizations:
+            lines.append(f"  Visualizations ({len(self.visualizations)}):")
+            for viz in self.visualizations:
+                lines.append(f"    {viz}")
+
         return "\n".join(lines)
 
     def view_cfast_input_file(self, pretty_print: bool = True) -> str:
@@ -1092,6 +1137,7 @@ class CFASTModel:
                 ("!! Fire", self.fires),
                 ("!! Device", self.devices),
                 ("!! Surface Connections", self.surface_connections),
+                ("!! Visualizations", self.visualizations),
             ]
 
             for header, items in sections:
@@ -1133,9 +1179,9 @@ class CFASTModel:
         - Duplicate ``id`` within any component list (compartments, fires, devices,
           wall/ceiling-floor/mechanical vents, material properties).
         - More than 100 compartments (hard CFAST limit).
-        - ``comp_id`` of a fire, device, vent, or surface connection referencing an
-          undefined compartment (``"OUTSIDE"`` is accepted as second compartment for
-          wall vents).
+        - ``comp_id`` of a fire, device, vent, surface connection, or visualization
+          referencing an undefined compartment (``"OUTSIDE"`` is accepted as second
+          compartment for wall vents).
         - ``material_id`` of a device or compartment surface (ceiling/wall/floor)
           referencing an undefined material.
         - ``device_id`` of a fire or vent referencing an undefined device.
@@ -1237,6 +1283,13 @@ class CFASTModel:
             if sc.comp_ids not in comp_ids:
                 raise ValueError(
                     f"SurfaceConnection: comp_ids='{sc.comp_ids}' does not match any defined compartment."
+                )
+
+        # comp_id of Visualization must exist in compartments (None means all compartments)
+        for viz in self.visualizations:
+            if viz.comp_id is not None and viz.comp_id not in comp_ids:
+                raise ValueError(
+                    f"Visualization: comp_id='{viz.comp_id}' does not match any defined compartment."
                 )
 
         material_map = {m.id: m for m in self.material_properties}

--- a/src/pycfast/parsers/cfast_parser.py
+++ b/src/pycfast/parsers/cfast_parser.py
@@ -23,6 +23,7 @@ from ..mechanical_vent import MechanicalVent
 from ..model import CFASTModel
 from ..simulation_environment import SimulationEnvironment
 from ..surface_connection import SurfaceConnection
+from ..visualization import Visualization
 from ..wall_vent import WallVent
 
 # CFAST namelist block type constants
@@ -39,6 +40,8 @@ BLOCK_TYPE_CHEM = "CHEM"
 BLOCK_TYPE_TABL = "TABL"
 BLOCK_TYPE_DEVC = "DEVC"
 BLOCK_TYPE_CONN = "CONN"
+BLOCK_TYPE_ISOF = "ISOF"
+BLOCK_TYPE_SLCF = "SLCF"
 BLOCK_TYPE_TAIL = "TAIL"
 
 # VENT type constants
@@ -76,6 +79,8 @@ class CFASTParser:
         List of Device objects.
     surface_connections: List[SurfaceConnection]
         List of SurfaceConnection objects.
+    visualizations: List[Visualization]
+        List of Visualization objects.
     """
 
     def __init__(self) -> None:
@@ -99,6 +104,7 @@ class CFASTParser:
         self.fires: list[Fire] = []
         self.devices: list[Device] = []
         self.surface_connections: list[SurfaceConnection] = []
+        self.visualizations: list[Visualization] = []
 
         # &FIRE records are collected as pending instances while &CHEM / &TABL
         # records are collected per fire_id. They are joined into
@@ -182,6 +188,7 @@ class CFASTParser:
             fires=self.fires,
             devices=self.devices,
             surface_connections=self.surface_connections,
+            visualizations=self.visualizations,
             file_name=file_name,
         )
 
@@ -216,6 +223,8 @@ class CFASTParser:
             BLOCK_TYPE_TABL.lower(): self._parse_table_block,
             BLOCK_TYPE_DEVC.lower(): self._parse_device_block,
             BLOCK_TYPE_CONN.lower(): self._parse_connection_block,
+            BLOCK_TYPE_ISOF.lower(): self._parse_isof_block,
+            BLOCK_TYPE_SLCF.lower(): self._parse_slcf_block,
         }
 
         # f90nml returns a dictionary with namelist names as keys (lowercase)
@@ -830,6 +839,37 @@ class CFASTParser:
             raise ValueError(f"Unknown Surface Connections type: {conn_type}")
 
         self.surface_connections.append(surface_connection)
+
+    def _parse_isof_block(self, params: dict[str, Any]) -> None:
+        """Parse an ISOF (isosurface visualization) namelist block."""
+        param_map = {
+            "value": {"source": "VALUE", "required": True, "type": float},
+            "comp_id": {"source": "COMP_ID", "type": str},
+        }
+        isof_params = self._extract_params(params, param_map)
+        self.visualizations.append(Visualization.isosurface(**isof_params))
+
+    def _parse_slcf_block(self, params: dict[str, Any]) -> None:
+        """Parse a SLCF (slice file visualization) namelist block."""
+        domain = self._get_param(params, "DOMAIN", required=True, param_type=str)
+
+        if domain == "2-D":
+            param_map = {
+                "plane": {"source": "PLANE", "required": True, "type": str},
+                "position": {"source": "POSITION", "default": 0.0, "type": float},
+                "comp_id": {"source": "COMP_ID", "type": str},
+            }
+            slcf_params = self._extract_params(params, param_map)
+            visualization = Visualization.slice_2d(**slcf_params)
+
+        elif domain == "3-D":
+            comp_id = self._get_param(params, "COMP_ID", param_type=str)
+            visualization = Visualization.slice_3d(comp_id=comp_id)
+
+        else:
+            raise ValueError(f"Unknown SLCF domain: {domain}")
+
+        self.visualizations.append(visualization)
 
 
 def sanitize_cfast_title_and_material(content: str) -> str:

--- a/src/pycfast/visualization.py
+++ b/src/pycfast/visualization.py
@@ -138,12 +138,15 @@ class Visualization(CFASTComponent):
                 f"Visualization: viz_type='{self.viz_type}' must be one of {set(self.VALID_TYPES)}."
             )
 
-        if self.comp_id is not None and (
-            not isinstance(self.comp_id, str) or not self.comp_id
-        ):
-            raise ValueError(
-                "Visualization: comp_id must be a non-empty string or None."
-            )
+        if self.comp_id is not None:
+            if not isinstance(self.comp_id, str):
+                raise TypeError(
+                    f"Visualization: comp_id must be a str, got {type(self.comp_id).__name__}."
+                )
+            if not self.comp_id:
+                raise ValueError(
+                    "Visualization: comp_id must be a non-empty string or None."
+                )
 
         if self.viz_type == "2-D":
             if self.plane is None:

--- a/src/pycfast/visualization.py
+++ b/src/pycfast/visualization.py
@@ -35,8 +35,7 @@ class Visualization(CFASTComponent):
       temperature is equal to the value specified.
 
     Visualizations can be placed in a single compartment or, when no
-    compartment is specified, at the same position and axis in all
-    compartments.
+    compartment is specified, in all compartments.
 
     Parameters
     ----------
@@ -46,15 +45,16 @@ class Visualization(CFASTComponent):
         3-D surface of constant gas temperature.
     comp_id : str | None
         Compartment ID where the visualization is placed. If None (default),
-        the visualization applies to all compartments. Validated against the
-        model compartments in CFASTModel._validate_dependencies.
+        the visualization applies to all compartments.
     plane : str | None
         Axis perpendicular to the slice ("X", "Y" or "Z"). Required for
         2-D slices, must be None otherwise.
     position : float | None
-        Position (m) along the specified axis where the slice is placed,
-        measured from the compartment origin. Required for 2-D slices,
-        must be None otherwise.
+        Position (m) along the specified axis where the slice is placed:
+        measured from the compartment origin when comp_id is given, in
+        absolute domain coordinates when comp_id is None (compartments the
+        plane does not intersect are silently skipped). Required for 2-D
+        slices, must be None otherwise.
     value : float | None
         Gas temperature (°C) of the isosurface. Required for isosurfaces,
         must be None otherwise.
@@ -75,7 +75,7 @@ class Visualization(CFASTComponent):
     By default, slice files are generated with a grid of 50 data points in
     each direction for each compartment specified. The grid spacing can be
     adjusted individually by compartment with the ``grid`` parameter of
-    :class:`Compartment`.
+    :class:`Compartment` (not implemented yet).
 
     Examples
     --------
@@ -262,15 +262,13 @@ class Visualization(CFASTComponent):
 
         Parameters
         ----------
-        plane : str
-            Axis perpendicular to the slice ("X", "Y" or "Z"). The slice is
-            placed perpendicular to the selected axis.
-        position : float
-            Position (m) along the specified axis where the slice is placed,
-            measured from the compartment origin. Default: 0.0.
-        comp_id : str | None
-            Compartment identifier. If None (default), the slice is placed
-            at the same position and axis in all compartments.
+        plane: str
+            Axis perpendicular to the slice ("X", "Y" or "Z")
+        position: float
+            Position (m) along the axis: relative to the compartment origin
+            if comp_id is given, absolute if None. Default: 0.0
+        comp_id: str | None
+            Compartment ID, or None (default) for all compartments
 
         Returns
         -------
@@ -290,9 +288,8 @@ class Visualization(CFASTComponent):
 
         Parameters
         ----------
-        comp_id : str | None
-            Compartment identifier. If None (default), a 3-D slice is
-            created in all compartments.
+        comp_id: str | None
+            Compartment ID, or None (default) for all compartments
 
         Returns
         -------
@@ -312,11 +309,10 @@ class Visualization(CFASTComponent):
 
         Parameters
         ----------
-        value : float
-            Gas temperature (°C) of the isosurface.
-        comp_id : str | None
-            Compartment identifier. If None (default), the isosurface is
-            created in all compartments.
+        value: float
+            Gas temperature (°C) of the isosurface
+        comp_id: str | None
+            Compartment ID, or None (default) for all compartments
 
         Returns
         -------

--- a/src/pycfast/visualization.py
+++ b/src/pycfast/visualization.py
@@ -1,0 +1,330 @@
+"""
+Visualizations module for CFAST simulations.
+
+This module provides the Visualization class for defining Smokeview
+visualization outputs (2-D slices, 3-D slices, and isosurfaces) in a
+CFAST simulation.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from ._base_component import CFASTComponent
+from .utils.namelist import NamelistRecord
+
+
+class Visualization(CFASTComponent):
+    """
+    Represents a Smokeview visualization output in CFAST.
+
+    Calculated results from a CFAST simulation can be visualized using
+    Smokeview. In addition to a simplified view of the layer temperatures
+    and vent flows, more detailed estimates of gas temperature and gas
+    velocity can be visualized.
+
+    There are three types of visualizations:
+
+    - **2-D slice** (``&SLCF DOMAIN = '2-D'``): a single plane slice of
+      temperature at the position and axis specified. The slice is placed
+      perpendicular to the selected axis (the Y-Z plane for the X axis,
+      the X-Z plane for the Y axis, and the X-Y plane for the Z axis).
+    - **3-D slice** (``&SLCF DOMAIN = '3-D'``): a set of three animated
+      slices whose position can be moved along their respective axes.
+    - **Isosurface** (``&ISOF``): a fixed 3-D surface where the gas
+      temperature is equal to the value specified.
+
+    Visualizations can be placed in a single compartment or, when no
+    compartment is specified, at the same position and axis in all
+    compartments.
+
+    Parameters
+    ----------
+    viz_type : str
+        Type of visualization. Options: "2-D" for a single plane slice,
+        "3-D" for a set of three animated slices, "ISOSURFACE" for a fixed
+        3-D surface of constant gas temperature.
+    comp_id : str | None
+        Compartment ID where the visualization is placed. If None (default),
+        the visualization applies to all compartments. Validated against the
+        model compartments in CFASTModel._validate_dependencies.
+    plane : str | None
+        Axis perpendicular to the slice ("X", "Y" or "Z"). Required for
+        2-D slices, must be None otherwise.
+    position : float | None
+        Position (m) along the specified axis where the slice is placed,
+        measured from the compartment origin. Required for 2-D slices,
+        must be None otherwise.
+    value : float | None
+        Gas temperature (°C) of the isosurface. Required for isosurfaces,
+        must be None otherwise.
+
+    Raises
+    ------
+    TypeError
+        If viz_type, comp_id or plane are not strings, or if position or
+        value are not numeric when provided.
+    ValueError
+        If viz_type is not "2-D", "3-D" or "ISOSURFACE", if comp_id is an
+        empty string, if plane or position are missing for a 2-D slice,
+        if plane is not "X", "Y" or "Z", if position is negative, or if
+        value is missing for an isosurface.
+
+    Notes
+    -----
+    By default, slice files are generated with a grid of 50 data points in
+    each direction for each compartment specified. The grid spacing can be
+    adjusted individually by compartment with the ``grid`` parameter of
+    :class:`Compartment`.
+
+    Examples
+    --------
+    Create a 2-D temperature slice in all compartments:
+
+    >>> slice_2d = Visualization.slice_2d(plane="X", position=2.5)
+
+    Create a 3-D slice in a single compartment:
+
+    >>> slice_3d = Visualization.slice_3d(comp_id="ROOM1")
+
+    Create an isosurface of gas temperature at 305 °C:
+
+    >>> isosurface = Visualization.isosurface(value=305.0)
+    """
+
+    VALID_TYPES: frozenset[str] = frozenset({"2-D", "3-D", "ISOSURFACE"})
+    VALID_PLANES: frozenset[str] = frozenset({"X", "Y", "Z"})
+
+    def __init__(
+        self,
+        viz_type: str,
+        comp_id: str | None = None,
+        plane: str | None = None,
+        position: float | None = None,
+        value: float | None = None,
+    ):
+        self.viz_type = viz_type  # "2-D", "3-D" or "ISOSURFACE"
+        self.comp_id = comp_id  # None means all compartments, to be validated in _validate_dependencies in CFASTModel
+        self.plane = plane
+        self.position = position
+        self.value = value
+
+        self._validate()
+        self._initialized = True
+
+    def _validate(self) -> None:
+        """Validate the current state of the visualization attributes.
+
+        Raises
+        ------
+        TypeError
+            If viz_type, comp_id or plane are not strings, or if position
+            or value are not numeric when provided.
+        ValueError
+            If any attribute violates the constraints.
+
+        Warns
+        -----
+        UserWarning
+            If plane, position or value are provided for a visualization
+            type that does not use them (should be None).
+        """
+        if not isinstance(self.viz_type, str):
+            raise TypeError(
+                f"Visualization: viz_type must be a str, got {type(self.viz_type).__name__}."
+            )
+        if self.viz_type not in self.VALID_TYPES:
+            raise ValueError(
+                f"Visualization: viz_type='{self.viz_type}' must be one of {set(self.VALID_TYPES)}."
+            )
+
+        if self.comp_id is not None and (
+            not isinstance(self.comp_id, str) or not self.comp_id
+        ):
+            raise ValueError(
+                "Visualization: comp_id must be a non-empty string or None."
+            )
+
+        if self.viz_type == "2-D":
+            if self.plane is None:
+                raise ValueError("Visualization: 2-D slice requires a plane value.")
+            if not isinstance(self.plane, str):
+                raise TypeError(
+                    f"Visualization: plane must be a str, got {type(self.plane).__name__}."
+                )
+            if self.plane not in self.VALID_PLANES:
+                raise ValueError(
+                    f"Visualization: plane='{self.plane}' must be one of {set(self.VALID_PLANES)}."
+                )
+            if self.position is None:
+                raise ValueError("Visualization: 2-D slice requires a position value.")
+            if not isinstance(self.position, (int, float)):
+                raise TypeError(
+                    f"Visualization: position must be a float, got {type(self.position).__name__}."
+                )
+            if self.position < 0:
+                raise ValueError(
+                    f"Visualization: position={self.position} must be >= 0 for 2-D slices."
+                )
+            if self.value is not None:
+                warnings.warn(
+                    "Visualization: value should be None for 2-D slices.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        elif self.viz_type == "3-D":
+            if any(v is not None for v in (self.plane, self.position, self.value)):
+                warnings.warn(
+                    "Visualization: plane, position and value should be None for 3-D slices.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        else:  # ISOSURFACE
+            if self.value is None:
+                raise ValueError("Visualization: isosurface requires a value.")
+            if not isinstance(self.value, (int, float)):
+                raise TypeError(
+                    f"Visualization: value must be a float, got {type(self.value).__name__}."
+                )
+            if self.plane is not None or self.position is not None:
+                warnings.warn(
+                    "Visualization: plane and position should be None for isosurfaces.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation of the Visualization."""
+        return (
+            f"Visualization("
+            f"viz_type='{self.viz_type}', "
+            f"comp_id={self.comp_id!r}, "
+            f"plane={self.plane!r}, "
+            f"position={self.position}, "
+            f"value={self.value}"
+            ")"
+        )
+
+    def __str__(self) -> str:
+        """Return a user-friendly string representation of the Visualization."""
+        compartment = self.comp_id if self.comp_id is not None else "all compartments"
+        if self.viz_type == "2-D":
+            details = f"plane {self.plane} at {self.position} m"
+        elif self.viz_type == "3-D":
+            details = "animated slices"
+        else:  # ISOSURFACE
+            details = f"{self.value} °C"
+        return f"Visualization ({self.viz_type}): {details} in {compartment}"
+
+    def to_input_string(self) -> str:
+        """
+        Convert the visualization to a formatted string for CFAST input file.
+
+        Returns
+        -------
+        str
+            Formatted string ready for inclusion in CFAST input file.
+
+        Examples
+        --------
+        >>> slice_2d = Visualization.slice_2d(plane="X", position=2.5)
+        >>> print(slice_2d.to_input_string())
+        &SLCF DOMAIN = '2-D' PLANE = 'X' POSITION = 2.5 /
+
+        >>> slice_3d = Visualization.slice_3d(comp_id="ROOM1")
+        >>> print(slice_3d.to_input_string())
+        &SLCF COMP_ID = 'ROOM1' DOMAIN = '3-D' /
+
+        >>> isosurface = Visualization.isosurface(value=305.0)
+        >>> print(isosurface.to_input_string())
+        &ISOF VALUE = 305.0 /
+        """
+        if self.viz_type == "ISOSURFACE":
+            rec = NamelistRecord("ISOF")
+            rec.add_field("COMP_ID", self.comp_id)
+            rec.add_field("VALUE", self.value)
+            return rec.build()
+
+        rec = NamelistRecord("SLCF")
+        rec.add_field("COMP_ID", self.comp_id)
+        rec.add_field("DOMAIN", self.viz_type)
+        if self.viz_type == "2-D":
+            rec.add_field("PLANE", self.plane)
+            rec.add_field("POSITION", self.position)
+        return rec.build()
+
+    @classmethod
+    def slice_2d(
+        cls, plane: str, position: float = 0.0, comp_id: str | None = None
+    ) -> Visualization:
+        """
+        Create a 2-D slice visualization of gas temperature.
+
+        Parameters
+        ----------
+        plane : str
+            Axis perpendicular to the slice ("X", "Y" or "Z"). The slice is
+            placed perpendicular to the selected axis.
+        position : float
+            Position (m) along the specified axis where the slice is placed,
+            measured from the compartment origin. Default: 0.0.
+        comp_id : str | None
+            Compartment identifier. If None (default), the slice is placed
+            at the same position and axis in all compartments.
+
+        Returns
+        -------
+        Visualization
+            Configured visualization instance for a 2-D slice.
+
+        Examples
+        --------
+        >>> slice_2d = Visualization.slice_2d(plane="Y", position=1.2, comp_id="ROOM1")
+        """
+        return cls(viz_type="2-D", comp_id=comp_id, plane=plane, position=position)
+
+    @classmethod
+    def slice_3d(cls, comp_id: str | None = None) -> Visualization:
+        """
+        Create a 3-D slice visualization of gas temperature.
+
+        Parameters
+        ----------
+        comp_id : str | None
+            Compartment identifier. If None (default), a 3-D slice is
+            created in all compartments.
+
+        Returns
+        -------
+        Visualization
+            Configured visualization instance for a 3-D slice.
+
+        Examples
+        --------
+        >>> slice_3d = Visualization.slice_3d(comp_id="ROOM1")
+        """
+        return cls(viz_type="3-D", comp_id=comp_id)
+
+    @classmethod
+    def isosurface(cls, value: float, comp_id: str | None = None) -> Visualization:
+        """
+        Create an isosurface visualization of gas temperature.
+
+        Parameters
+        ----------
+        value : float
+            Gas temperature (°C) of the isosurface.
+        comp_id : str | None
+            Compartment identifier. If None (default), the isosurface is
+            created in all compartments.
+
+        Returns
+        -------
+        Visualization
+            Configured visualization instance for an isosurface.
+
+        Examples
+        --------
+        >>> isosurface = Visualization.isosurface(value=305.0, comp_id="ROOM1")
+        """
+        return cls(viz_type="ISOSURFACE", comp_id=comp_id, value=value)

--- a/tests/units/test_cfast_parser.py
+++ b/tests/units/test_cfast_parser.py
@@ -208,17 +208,6 @@ class TestCFASTParser:
             assert isosurface.viz_type == "ISOSURFACE"
             assert isosurface.value == 305.0
             assert isosurface.comp_id is None
-
-            # Round-trip: parsed visualizations regenerate equivalent namelists
-            assert (
-                slice_2d.to_input_string()
-                == "&SLCF DOMAIN = '2-D' PLANE = 'X' POSITION = 2.5 /\n"
-            )
-            assert (
-                slice_3d.to_input_string()
-                == "&SLCF COMP_ID = 'Room1' DOMAIN = '3-D' /\n"
-            )
-            assert isosurface.to_input_string() == "&ISOF VALUE = 305.0 /\n"
         finally:
             os.unlink(temp_file)
 

--- a/tests/units/test_cfast_parser.py
+++ b/tests/units/test_cfast_parser.py
@@ -33,6 +33,7 @@ class TestCFASTParser:
         assert parser.fires == []
         assert parser.devices == []
         assert parser.surface_connections == []
+        assert parser.visualizations == []
         assert parser._pending_fires == []
         assert parser._fire_chem == {}
         assert parser._fire_data_rows == {}
@@ -57,6 +58,7 @@ class TestCFASTParser:
         assert parser.fires == []
         assert parser.devices == []
         assert parser.surface_connections == []
+        assert parser.visualizations == []
         assert parser._pending_fires == []
         assert parser._fire_chem == {}
         assert parser._fire_data_rows == {}
@@ -171,6 +173,88 @@ class TestCFASTParser:
             assert "&DIAG RESIDUE = .TRUE." in model.simulation_environment.extra_custom
         finally:
             os.unlink(temp_file)
+
+    def test_parse_file_with_visualizations(self):
+        """Test parsing a file with SLCF and ISOF visualization blocks."""
+        content_with_visualizations = """&HEAD VERSION = 7600, TITLE = 'Visualization Test' /
+                                         &TIME SIMULATION = 900 /
+                                         &COMP ID = 'Room1', DEPTH = 5, HEIGHT = 3, WIDTH = 4, ORIGIN = 0, 0, 0 /
+                                         &SLCF DOMAIN = '2-D'  POSITION = 2.5, PLANE = 'X' /
+                                         &SLCF COMP_ID = 'Room1' DOMAIN = '3-D' /
+                                         &ISOF VALUE = 305 /
+                                         &TAIL /"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".in", delete=False) as f:
+            f.write(content_with_visualizations)
+            temp_file = f.name
+
+        try:
+            parser = CFASTParser()
+            model = parser.parse_file(temp_file)
+
+            assert len(model.visualizations) == 3
+
+            slice_2d = model.visualizations[0]
+            assert slice_2d.viz_type == "2-D"
+            assert slice_2d.plane == "X"
+            assert slice_2d.position == 2.5
+            assert slice_2d.comp_id is None
+
+            slice_3d = model.visualizations[1]
+            assert slice_3d.viz_type == "3-D"
+            assert slice_3d.comp_id == "Room1"
+
+            isosurface = model.visualizations[2]
+            assert isosurface.viz_type == "ISOSURFACE"
+            assert isosurface.value == 305.0
+            assert isosurface.comp_id is None
+
+            # Round-trip: parsed visualizations regenerate equivalent namelists
+            assert (
+                slice_2d.to_input_string()
+                == "&SLCF DOMAIN = '2-D' PLANE = 'X' POSITION = 2.5 /\n"
+            )
+            assert (
+                slice_3d.to_input_string()
+                == "&SLCF COMP_ID = 'Room1' DOMAIN = '3-D' /\n"
+            )
+            assert isosurface.to_input_string() == "&ISOF VALUE = 305.0 /\n"
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_file_slcf_default_position(self):
+        """Test that a 2-D SLCF block without POSITION defaults to 0.0."""
+        content = """&HEAD VERSION = 7600, TITLE = 'SLCF Default Test' /
+                     &TIME SIMULATION = 900 /
+                     &COMP ID = 'Room1', DEPTH = 5, HEIGHT = 3, WIDTH = 4, ORIGIN = 0, 0, 0 /
+                     &SLCF DOMAIN = '2-D' PLANE = 'Y' /
+                     &TAIL /"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".in", delete=False) as f:
+            f.write(content)
+            temp_file = f.name
+
+        try:
+            parser = CFASTParser()
+            model = parser.parse_file(temp_file)
+
+            assert len(model.visualizations) == 1
+            assert model.visualizations[0].plane == "Y"
+            assert model.visualizations[0].position == 0.0
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_slcf_block_unknown_domain(self):
+        """Test that an unknown SLCF domain raises a ValueError."""
+        parser = CFASTParser()
+        with pytest.raises(ValueError, match="Unknown SLCF domain"):
+            parser._parse_slcf_block({"DOMAIN": "4-D"})
+
+    def test_parse_isof_block_missing_value(self):
+        """Test that an ISOF block without VALUE raises a ValueError."""
+        parser = CFASTParser()
+        with pytest.raises(ValueError, match="Missing required parameter: VALUE"):
+            parser._parse_isof_block({"COMP_ID": "Room1"})
 
     def test_parse_file_with_unknown_block(self):
         """Test parsing a file with unknown block type (should warn but not fail)."""

--- a/tests/units/test_model.py
+++ b/tests/units/test_model.py
@@ -18,6 +18,7 @@ from pycfast.mechanical_vent import MechanicalVent
 from pycfast.model import CFASTModel, _resolve_cfast_exe
 from pycfast.simulation_environment import SimulationEnvironment
 from pycfast.surface_connection import SurfaceConnection
+from pycfast.visualization import Visualization
 from pycfast.wall_vent import WallVent
 
 """
@@ -98,6 +99,12 @@ class TestCFASTModel:
             fraction=0.5,
         )
 
+        visualization = Visualization.slice_2d(
+            plane="X",
+            position=1.5,
+            comp_id="ROOM1",
+        )
+
         return CFASTModel(
             simulation_environment=simulation_env,
             compartments=[compartment1, compartment2],
@@ -108,6 +115,7 @@ class TestCFASTModel:
             fires=[fire],
             devices=[device],
             surface_connections=[surface_conn],
+            visualizations=[visualization],
             file_name="full_test.in",
         )
 
@@ -125,6 +133,7 @@ class TestCFASTModel:
         assert model.fires == []
         assert model.devices == []
         assert model.surface_connections == []
+        assert model.visualizations == []
         assert model.file_name == "test.in"
         assert model.extra_arguments == []
 
@@ -141,6 +150,7 @@ class TestCFASTModel:
         assert len(model.fires) == 1
         assert len(model.devices) == 1
         assert len(model.surface_connections) == 1
+        assert len(model.visualizations) == 1
         assert model.file_name == "full_test.in"
 
     def test_init_with_extra_arguments(self):
@@ -215,6 +225,7 @@ class TestCFASTModel:
                 assert "&FIRE ID = 'FIRE1'" in content
                 assert "&DEVC ID = 'TEMP1'" in content
                 assert "&CONN TYPE = 'WALL'" in content
+                assert "&SLCF COMP_ID = 'ROOM1' DOMAIN = '2-D'" in content
                 assert "&TAIL /" in content
 
     def test_write_input_section_order(self):
@@ -233,10 +244,13 @@ class TestCFASTModel:
                 matl_pos = content.find("&MATL")
                 comp_pos = content.find("&COMP")
                 fire_pos = content.find("&FIRE")
+                slcf_pos = content.find("&SLCF")
                 tail_pos = content.find("&TAIL")
 
                 # Check order (all should be >= 0 and in ascending order)
-                assert 0 <= head_pos < matl_pos < comp_pos < fire_pos < tail_pos
+                assert (
+                    0 <= head_pos < matl_pos < comp_pos < fire_pos < slcf_pos < tail_pos
+                )
 
     def test_write_input_file(self):
         """Test writing input file to disk."""
@@ -648,6 +662,7 @@ class TestCFASTModel:
         assert "wall_vents=1" in repr_str
         assert "devices=1" in repr_str
         assert "material_properties=1" in repr_str
+        assert "visualizations=1" in repr_str
 
     def test_str(self):
         """Test __str__ method delegates to summary()."""
@@ -683,6 +698,7 @@ class TestCFASTModel:
         )  # This is included in the full model
         assert "devices" in component_types
         assert "material_properties" in component_types
+        assert "visualizations" in component_types
 
     def test_iter_minimal(self) -> None:
         """Test __iter__ method with minimal model."""
@@ -715,6 +731,7 @@ class TestCFASTModel:
         assert "Fire (1):" in result
         assert "Wall Vents (1):" in result
         assert "Device (1):" in result
+        assert "Visualizations (1):" in result
 
     # Tests for update methods
     def test_update_fire_params(self) -> None:
@@ -1007,6 +1024,27 @@ class TestCFASTModel:
         # Check that new model has updated values
         assert updated_model.surface_connections[0].fraction == 0.8
 
+    def test_update_visualization_params(self) -> None:
+        """Test update_visualization_params method."""
+        model = self.create_full_model()
+        original_position = model.visualizations[0].position
+
+        # Test updating visualization parameters (only supports index)
+        updated_model = model.update_visualization_params(visualization=0, position=2.0)
+
+        # Check that original model is unchanged
+        assert model.visualizations[0].position == original_position
+
+        # Check that new model has updated values
+        assert updated_model.visualizations[0].position == 2.0
+
+    def test_update_visualization_params_invalid_comp_id(self) -> None:
+        """Test that updating a visualization with an unknown comp_id raises."""
+        model = self.create_full_model()
+
+        with pytest.raises(ValueError, match="does not match any defined compartment"):
+            model.update_visualization_params(visualization=0, comp_id="UNKNOWN_ROOM")
+
     def test_method_chaining(self) -> None:
         """Test that update methods can be chained."""
         model = self.create_full_model()
@@ -1215,6 +1253,31 @@ class TestCFASTModel:
         assert updated_model.surface_connections[-1].comp_ids == "ROOM2"
         assert updated_model.surface_connections[-1].fraction == 0.5
 
+    def test_add_visualization(self) -> None:
+        """Test adding a visualization to the model."""
+        model = self.create_full_model()
+        original_viz_count = len(model.visualizations)
+
+        isosurface = Visualization.isosurface(value=305.0, comp_id="ROOM2")
+        updated_model = model.add(isosurface)
+
+        # Check that original model is unchanged
+        assert len(model.visualizations) == original_viz_count
+
+        # Check that new model has additional visualization
+        assert len(updated_model.visualizations) == original_viz_count + 1
+        assert updated_model.visualizations[-1].viz_type == "ISOSURFACE"
+        assert updated_model.visualizations[-1].comp_id == "ROOM2"
+        assert updated_model.visualizations[-1].value == 305.0
+
+    def test_add_visualization_invalid_comp_id(self) -> None:
+        """Test that adding a visualization with an unknown comp_id raises."""
+        model = self.create_full_model()
+
+        isosurface = Visualization.isosurface(value=305.0, comp_id="UNKNOWN_ROOM")
+        with pytest.raises(ValueError, match="does not match any defined compartment"):
+            model.add(isosurface)
+
     def test_add_methods_chaining(self) -> None:
         """Test that add methods can be chained together."""
         model = self.create_full_model()
@@ -1264,6 +1327,7 @@ class TestCFASTModel:
             devices=None,
             material_properties=None,
             surface_connections=None,
+            visualizations=None,
         )
 
         # Test adding to None lists
@@ -1284,11 +1348,14 @@ class TestCFASTModel:
             thickness=0.15,
         )
 
-        updated_model = model.add(fire).add(device).add(material)
+        visualization = Visualization.slice_3d(comp_id="ROOM1")
+
+        updated_model = model.add(fire).add(device).add(material).add(visualization)
 
         assert len(updated_model.fires) == 1
         assert len(updated_model.devices) == 1
         assert len(updated_model.material_properties) == 1
+        assert len(updated_model.visualizations) == 1
 
     def test_add_unsupported_type_raises(self) -> None:
         """add() must reject objects that are not a known component type."""

--- a/tests/units/test_model.py
+++ b/tests/units/test_model.py
@@ -1278,6 +1278,14 @@ class TestCFASTModel:
         with pytest.raises(ValueError, match="does not match any defined compartment"):
             model.add(isosurface)
 
+    def test_add_visualization_comp_id_none(self) -> None:
+        """Test that a visualization with comp_id=None passes dependency validation."""
+        model = self.create_full_model()
+
+        updated_model = model.add(Visualization.isosurface(value=305.0))
+
+        assert updated_model.visualizations[-1].comp_id is None
+
     def test_add_methods_chaining(self) -> None:
         """Test that add methods can be chained together."""
         model = self.create_full_model()

--- a/tests/units/test_visualization.py
+++ b/tests/units/test_visualization.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import pytest
+
+from pycfast.visualization import Visualization
+
+"""
+Tests for the Visualization class.
+"""
+
+
+class TestVisualization:
+    """Test class for Visualization."""
+
+    def test_init_2d_slice(self):
+        """Test initialization of a 2-D slice visualization."""
+        viz = Visualization(
+            viz_type="2-D",
+            comp_id="ROOM1",
+            plane="X",
+            position=2.5,
+        )
+        assert viz.viz_type == "2-D"
+        assert viz.comp_id == "ROOM1"
+        assert viz.plane == "X"
+        assert viz.position == 2.5
+        assert viz.value is None
+
+    def test_init_3d_slice(self):
+        """Test initialization of a 3-D slice visualization."""
+        viz = Visualization(viz_type="3-D", comp_id="ROOM1")
+        assert viz.viz_type == "3-D"
+        assert viz.comp_id == "ROOM1"
+        assert viz.plane is None
+        assert viz.position is None
+        assert viz.value is None
+
+    def test_init_isosurface(self):
+        """Test initialization of an isosurface visualization."""
+        viz = Visualization(viz_type="ISOSURFACE", value=305.0)
+        assert viz.viz_type == "ISOSURFACE"
+        assert viz.comp_id is None
+        assert viz.value == 305.0
+
+    def test_to_input_string_2d_slice(self):
+        """Test input string generation for a 2-D slice."""
+        viz = Visualization(viz_type="2-D", comp_id="ROOM1", plane="Y", position=1.2)
+        result = viz.to_input_string()
+        assert result.startswith("&SLCF")
+        assert result.endswith("/\n")
+        assert "COMP_ID = 'ROOM1'" in result
+        assert "DOMAIN = '2-D'" in result
+        assert "PLANE = 'Y'" in result
+        assert "POSITION = 1.2" in result
+        assert "None" not in result
+
+    def test_to_input_string_2d_slice_all_compartments(self):
+        """Test that COMP_ID is omitted when comp_id is None (all compartments)."""
+        viz = Visualization(viz_type="2-D", plane="X", position=0.0)
+        result = viz.to_input_string()
+        assert result.startswith("&SLCF")
+        assert "COMP_ID" not in result
+        assert "DOMAIN = '2-D'" in result
+        assert "PLANE = 'X'" in result
+        assert "POSITION = 0.0" in result
+
+    def test_to_input_string_3d_slice(self):
+        """Test input string generation for a 3-D slice."""
+        viz = Visualization(viz_type="3-D", comp_id="ROOM1")
+        result = viz.to_input_string()
+        assert result.startswith("&SLCF")
+        assert result.endswith("/\n")
+        assert "COMP_ID = 'ROOM1'" in result
+        assert "DOMAIN = '3-D'" in result
+        assert "PLANE" not in result
+        assert "POSITION" not in result
+
+    def test_to_input_string_isosurface(self):
+        """Test input string generation for an isosurface."""
+        viz = Visualization(viz_type="ISOSURFACE", value=305.0)
+        result = viz.to_input_string()
+        assert result.startswith("&ISOF")
+        assert result.endswith("/\n")
+        assert "VALUE = 305.0" in result
+        assert "COMP_ID" not in result
+        assert "DOMAIN" not in result
+
+    def test_to_input_string_isosurface_with_compartment(self):
+        """Test input string generation for an isosurface in a single compartment."""
+        viz = Visualization(viz_type="ISOSURFACE", comp_id="ROOM1", value=100.0)
+        result = viz.to_input_string()
+        assert result.startswith("&ISOF")
+        assert "COMP_ID = 'ROOM1'" in result
+        assert "VALUE = 100.0" in result
+
+    def test_slice_2d_classmethod(self):
+        """Test the slice_2d class method."""
+        viz = Visualization.slice_2d(plane="Z", position=2.3, comp_id="KITCHEN")
+        assert isinstance(viz, Visualization)
+        assert viz.viz_type == "2-D"
+        assert viz.plane == "Z"
+        assert viz.position == 2.3
+        assert viz.comp_id == "KITCHEN"
+
+    def test_slice_2d_classmethod_defaults(self):
+        """Test the slice_2d class method default values."""
+        viz = Visualization.slice_2d(plane="X")
+        assert viz.position == 0.0
+        assert viz.comp_id is None
+
+    def test_slice_3d_classmethod(self):
+        """Test the slice_3d class method."""
+        viz = Visualization.slice_3d(comp_id="LIVING")
+        assert isinstance(viz, Visualization)
+        assert viz.viz_type == "3-D"
+        assert viz.comp_id == "LIVING"
+
+    def test_isosurface_classmethod(self):
+        """Test the isosurface class method."""
+        viz = Visualization.isosurface(value=250.0)
+        assert isinstance(viz, Visualization)
+        assert viz.viz_type == "ISOSURFACE"
+        assert viz.value == 250.0
+        assert viz.comp_id is None
+
+    @pytest.mark.parametrize("plane", ["X", "Y", "Z"])
+    def test_to_input_string_2d_with_different_planes(self, plane: str):
+        """Test input string generation for 2-D slices with all valid planes."""
+        viz = Visualization.slice_2d(plane=plane, position=1.0)
+        result = viz.to_input_string()
+        assert f"PLANE = '{plane}'" in result
+
+    def test_init_invalid_viz_type(self):
+        """Test that initialization fails with an invalid viz_type."""
+        with pytest.raises(ValueError, match="must be one of"):
+            Visualization(viz_type="4-D")
+
+    def test_init_viz_type_not_str(self):
+        """Test that initialization fails when viz_type is not a string."""
+        with pytest.raises(TypeError, match="viz_type must be a str"):
+            Visualization(viz_type=123)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad_id", ["", 42])
+    def test_init_invalid_comp_id(self, bad_id: object):
+        """Test that initialization fails with an invalid comp_id."""
+        with pytest.raises(ValueError, match="comp_id must be a non-empty string"):
+            Visualization(viz_type="3-D", comp_id=bad_id)  # type: ignore[arg-type]
+
+    def test_init_2d_missing_plane(self):
+        """Test that 2-D slice fails without a plane value."""
+        with pytest.raises(ValueError, match="2-D slice requires a plane"):
+            Visualization(viz_type="2-D", position=1.0)
+
+    def test_init_2d_plane_not_str(self):
+        """Test that 2-D slice fails when plane is not a string."""
+        with pytest.raises(TypeError, match="plane must be a str"):
+            Visualization(viz_type="2-D", plane=1, position=1.0)  # type: ignore[arg-type]
+
+    def test_init_2d_invalid_plane(self):
+        """Test that 2-D slice fails with an invalid plane."""
+        with pytest.raises(ValueError, match="must be one of"):
+            Visualization(viz_type="2-D", plane="W", position=1.0)
+
+    def test_init_2d_missing_position(self):
+        """Test that 2-D slice fails without a position value."""
+        with pytest.raises(ValueError, match="2-D slice requires a position"):
+            Visualization(viz_type="2-D", plane="X")
+
+    def test_init_2d_position_not_numeric(self):
+        """Test that 2-D slice fails when position is not numeric."""
+        with pytest.raises(TypeError, match="position must be a float"):
+            Visualization(viz_type="2-D", plane="X", position="middle")  # type: ignore[arg-type]
+
+    def test_init_2d_negative_position(self):
+        """Test that 2-D slice fails with a negative position."""
+        with pytest.raises(ValueError, match="must be >= 0"):
+            Visualization(viz_type="2-D", plane="X", position=-1.0)
+
+    def test_init_isosurface_missing_value(self):
+        """Test that isosurface fails without a value."""
+        with pytest.raises(ValueError, match="isosurface requires a value"):
+            Visualization(viz_type="ISOSURFACE")
+
+    def test_init_isosurface_value_not_numeric(self):
+        """Test that isosurface fails when value is not numeric."""
+        with pytest.raises(TypeError, match="value must be a float"):
+            Visualization(viz_type="ISOSURFACE", value="hot")  # type: ignore[arg-type]
+
+    def test_init_2d_with_value_warning(self):
+        """Test that a warning is raised when value is provided for a 2-D slice."""
+        with pytest.warns(UserWarning, match="value should be None for 2-D"):
+            Visualization(viz_type="2-D", plane="X", position=1.0, value=300.0)
+
+    def test_init_3d_with_extra_fields_warning(self):
+        """Test that a warning is raised when extra fields are provided for a 3-D slice."""
+        with pytest.warns(UserWarning, match="should be None for 3-D"):
+            Visualization(viz_type="3-D", plane="X")
+
+    def test_init_isosurface_with_extra_fields_warning(self):
+        """Test that a warning is raised when plane/position are provided for an isosurface."""
+        with pytest.warns(UserWarning, match="should be None for isosurfaces"):
+            Visualization(viz_type="ISOSURFACE", value=300.0, position=1.0)
+
+    def test_to_input_string_3d_ignores_extra_fields(self):
+        """Test that 3-D slices don't include PLANE/POSITION even when provided."""
+        with pytest.warns(UserWarning):
+            viz = Visualization(viz_type="3-D", plane="X", position=1.0)
+        result = viz.to_input_string()
+        assert "PLANE" not in result
+        assert "POSITION" not in result
+
+    # Tests for dunder methods
+    def test_repr(self) -> None:
+        """Test __repr__ method."""
+        viz = Visualization(viz_type="2-D", comp_id="ROOM1", plane="X", position=2.5)
+
+        repr_str = repr(viz)
+        assert "Visualization(" in repr_str
+        assert "viz_type='2-D'" in repr_str
+        assert "comp_id='ROOM1'" in repr_str
+        assert "plane='X'" in repr_str
+        assert "position=2.5" in repr_str
+        assert "value=None" in repr_str
+
+    def test_repr_isosurface(self) -> None:
+        """Test __repr__ method for isosurface."""
+        viz = Visualization.isosurface(value=305.0)
+
+        repr_str = repr(viz)
+        assert "Visualization(" in repr_str
+        assert "viz_type='ISOSURFACE'" in repr_str
+        assert "comp_id=None" in repr_str
+        assert "value=305.0" in repr_str
+
+    def test_str_2d_slice(self) -> None:
+        """Test __str__ method for a 2-D slice."""
+        viz = Visualization.slice_2d(plane="X", position=2.5, comp_id="ROOM1")
+
+        str_repr = str(viz)
+        assert "Visualization (2-D):" in str_repr
+        assert "plane X at 2.5 m" in str_repr
+        assert "in ROOM1" in str_repr
+
+    def test_str_3d_slice_all_compartments(self) -> None:
+        """Test __str__ method for a 3-D slice in all compartments."""
+        viz = Visualization.slice_3d()
+
+        str_repr = str(viz)
+        assert "Visualization (3-D):" in str_repr
+        assert "in all compartments" in str_repr
+
+    def test_str_isosurface(self) -> None:
+        """Test __str__ method for an isosurface."""
+        viz = Visualization.isosurface(value=305.0)
+
+        str_repr = str(viz)
+        assert "Visualization (ISOSURFACE):" in str_repr
+        assert "305.0 °C" in str_repr
+
+    def test_setattr_updates_attributes(self) -> None:
+        """Test that attribute assignment updates the instance."""
+        viz = Visualization.slice_2d(plane="X", position=1.0, comp_id="ROOM1")
+
+        viz.plane = "Y"
+        assert viz.plane == "Y"
+
+        viz.position = 2.0
+        assert viz.position == 2.0
+
+        viz.comp_id = None
+        assert viz.comp_id is None
+
+    def test_setattr_invalid_raises(self) -> None:
+        """Setting an invalid value triggers validation and raises."""
+        viz = Visualization.slice_2d(plane="X", position=1.0)
+
+        with pytest.raises(ValueError):
+            viz.plane = "INVALID_PLANE"

--- a/tests/units/test_visualization.py
+++ b/tests/units/test_visualization.py
@@ -12,36 +12,6 @@ Tests for the Visualization class.
 class TestVisualization:
     """Test class for Visualization."""
 
-    def test_init_2d_slice(self):
-        """Test initialization of a 2-D slice visualization."""
-        viz = Visualization(
-            viz_type="2-D",
-            comp_id="ROOM1",
-            plane="X",
-            position=2.5,
-        )
-        assert viz.viz_type == "2-D"
-        assert viz.comp_id == "ROOM1"
-        assert viz.plane == "X"
-        assert viz.position == 2.5
-        assert viz.value is None
-
-    def test_init_3d_slice(self):
-        """Test initialization of a 3-D slice visualization."""
-        viz = Visualization(viz_type="3-D", comp_id="ROOM1")
-        assert viz.viz_type == "3-D"
-        assert viz.comp_id == "ROOM1"
-        assert viz.plane is None
-        assert viz.position is None
-        assert viz.value is None
-
-    def test_init_isosurface(self):
-        """Test initialization of an isosurface visualization."""
-        viz = Visualization(viz_type="ISOSURFACE", value=305.0)
-        assert viz.viz_type == "ISOSURFACE"
-        assert viz.comp_id is None
-        assert viz.value == 305.0
-
     def test_to_input_string_2d_slice(self):
         """Test input string generation for a 2-D slice."""
         viz = Visualization(viz_type="2-D", comp_id="ROOM1", plane="Y", position=1.2)
@@ -53,37 +23,6 @@ class TestVisualization:
         assert "PLANE = 'Y'" in result
         assert "POSITION = 1.2" in result
         assert "None" not in result
-
-    def test_to_input_string_2d_slice_all_compartments(self):
-        """Test that COMP_ID is omitted when comp_id is None (all compartments)."""
-        viz = Visualization(viz_type="2-D", plane="X", position=0.0)
-        result = viz.to_input_string()
-        assert result.startswith("&SLCF")
-        assert "COMP_ID" not in result
-        assert "DOMAIN = '2-D'" in result
-        assert "PLANE = 'X'" in result
-        assert "POSITION = 0.0" in result
-
-    def test_to_input_string_3d_slice(self):
-        """Test input string generation for a 3-D slice."""
-        viz = Visualization(viz_type="3-D", comp_id="ROOM1")
-        result = viz.to_input_string()
-        assert result.startswith("&SLCF")
-        assert result.endswith("/\n")
-        assert "COMP_ID = 'ROOM1'" in result
-        assert "DOMAIN = '3-D'" in result
-        assert "PLANE" not in result
-        assert "POSITION" not in result
-
-    def test_to_input_string_isosurface(self):
-        """Test input string generation for an isosurface."""
-        viz = Visualization(viz_type="ISOSURFACE", value=305.0)
-        result = viz.to_input_string()
-        assert result.startswith("&ISOF")
-        assert result.endswith("/\n")
-        assert "VALUE = 305.0" in result
-        assert "COMP_ID" not in result
-        assert "DOMAIN" not in result
 
     def test_to_input_string_isosurface_with_compartment(self):
         """Test input string generation for an isosurface in a single compartment."""
@@ -101,6 +40,7 @@ class TestVisualization:
         assert viz.plane == "Z"
         assert viz.position == 2.3
         assert viz.comp_id == "KITCHEN"
+        assert viz.value is None
 
     def test_slice_2d_classmethod_defaults(self):
         """Test the slice_2d class method default values."""
@@ -114,6 +54,9 @@ class TestVisualization:
         assert isinstance(viz, Visualization)
         assert viz.viz_type == "3-D"
         assert viz.comp_id == "LIVING"
+        assert viz.plane is None
+        assert viz.position is None
+        assert viz.value is None
 
     def test_isosurface_classmethod(self):
         """Test the isosurface class method."""
@@ -122,13 +65,6 @@ class TestVisualization:
         assert viz.viz_type == "ISOSURFACE"
         assert viz.value == 250.0
         assert viz.comp_id is None
-
-    @pytest.mark.parametrize("plane", ["X", "Y", "Z"])
-    def test_to_input_string_2d_with_different_planes(self, plane: str):
-        """Test input string generation for 2-D slices with all valid planes."""
-        viz = Visualization.slice_2d(plane=plane, position=1.0)
-        result = viz.to_input_string()
-        assert f"PLANE = '{plane}'" in result
 
     def test_init_invalid_viz_type(self):
         """Test that initialization fails with an invalid viz_type."""
@@ -140,11 +76,15 @@ class TestVisualization:
         with pytest.raises(TypeError, match="viz_type must be a str"):
             Visualization(viz_type=123)  # type: ignore[arg-type]
 
-    @pytest.mark.parametrize("bad_id", ["", 42])
-    def test_init_invalid_comp_id(self, bad_id: object):
-        """Test that initialization fails with an invalid comp_id."""
+    def test_init_invalid_comp_id(self):
+        """Test that initialization fails with an empty comp_id."""
         with pytest.raises(ValueError, match="comp_id must be a non-empty string"):
-            Visualization(viz_type="3-D", comp_id=bad_id)  # type: ignore[arg-type]
+            Visualization(viz_type="3-D", comp_id="")
+
+    def test_init_comp_id_not_str(self):
+        """Test that initialization fails when comp_id is not a string."""
+        with pytest.raises(TypeError, match="comp_id must be a str"):
+            Visualization(viz_type="3-D", comp_id=42)  # type: ignore[arg-type]
 
     def test_init_2d_missing_plane(self):
         """Test that 2-D slice fails without a plane value."""
@@ -221,16 +161,6 @@ class TestVisualization:
         assert "plane='X'" in repr_str
         assert "position=2.5" in repr_str
         assert "value=None" in repr_str
-
-    def test_repr_isosurface(self) -> None:
-        """Test __repr__ method for isosurface."""
-        viz = Visualization.isosurface(value=305.0)
-
-        repr_str = repr(viz)
-        assert "Visualization(" in repr_str
-        assert "viz_type='ISOSURFACE'" in repr_str
-        assert "comp_id=None" in repr_str
-        assert "value=305.0" in repr_str
 
     def test_str_2d_slice(self) -> None:
         """Test __str__ method for a 2-D slice."""


### PR DESCRIPTION
Closes #129

## What this adds

A new `Visualization` component class covering the three CFAST/Smokeview visualization types, following the formalism of the `&SLCF` and `&ISOF` namelists (see `docs/cfast-reference/Appendix_CFAST_Keywords.tex` and the `!! Visualizations` sections of the verification `.in` files):

```python
from pycfast import Visualization

slice_2d = Visualization.slice_2d(plane="X", position=2.5)          # &SLCF DOMAIN = '2-D' PLANE = 'X' POSITION = 2.5 /
slice_3d = Visualization.slice_3d(comp_id="ROOM1")                  # &SLCF COMP_ID = 'ROOM1' DOMAIN = '3-D' /
isosurface = Visualization.isosurface(value=305.0)                  # &ISOF VALUE = 305.0 /
```

`comp_id=None` (default) means the visualization applies to all compartments, matching the CEdit "All" default.

## Design

The class mirrors the existing component structure (`SurfaceConnection` as the closest template):

- Plain class inheriting `CFASTComponent`, with `_validate()` re-run on attribute writes, `to_input_string()` via `NamelistRecord`, `__repr__`/`__str__`, and factory classmethods with doctests.
- A single class with a `viz_type` discriminator (`"2-D"`, `"3-D"`, `"ISOSURFACE"`), the same pattern as `SurfaceConnection` (WALL/FLOOR) and `Device` (multi-TYPE) — and matching the API requested in #129 (`from pycfast import Visualization`).
- Validation: 2-D requires `plane` ∈ {X, Y, Z} and `position` ≥ 0; isosurface requires a numeric `value` (°C); extraneous fields raise a `UserWarning` like the FLOOR/fraction case in `SurfaceConnection`.

## Integration

- **`CFASTModel`**: new `visualizations` list wired into `_COMPONENT_SPECS` (so `add()` works automatically), `update_visualization_params()`, `summary()`/`__repr__`/`__iter__`, and `_validate_dependencies()` (a non-`None` `comp_id` must match a defined compartment). The input file writer emits a `!! Visualizations` section right before `&TAIL /`, matching the placement in the NIST verification files.
- **`CFASTParser`**: new `_parse_slcf_block()` / `_parse_isof_block()` handlers. These blocks were previously dropped with an `Unknown block type` warning, so files like `Verification/Ventilation/ventilation_1.in` now round-trip losslessly.
- **Exports/docs**: `Visualization` exported from the package root and added to `docs/source/api/components.rst`.

## Tests

- New `tests/units/test_visualization.py` (init, exact output strings, factories, parametrized validation errors, warnings, dunders, `__setattr__` re-validation).
- `test_model.py`: full model fixture now includes a visualization; new add/update/dependency-validation tests; section-order test asserts `&SLCF` lands between `&FIRE` and `&TAIL`.
- `test_cfast_parser.py`: parse tests for 2-D/3-D SLCF and ISOF (using the exact formatting found in the verification files, e.g. `&SLCF DOMAIN = '2-D'  POSITION = 2.5, PLANE = 'X' /`), default-position handling, and error cases.
- Verified end-to-end by parsing and re-saving `ventilation_1.in`, `ventilation_2.in` and the NRC trash-fire file: visualizations survive the round-trip and are written under `!! Visualizations` before `&TAIL /`.

`make check`, `make format`, `make type` (mypy strict) and `make test-units`/`test-doctest` pass — except the 6 pre-existing `test_run_*` failures that require a local CFAST binary, which fail identically on `main` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKNmYRvPHgYVahv4N5owQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKNmYRvPHgYVahv4N5owQJ)_